### PR TITLE
use toit SDK layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,12 @@ $(BUILD_DIR)/jag: $(GO_SOURCE)
 snapshot: $(BUILD_DIR)/jaguar.snapshot
 
 $(BUILD_DIR)/jaguar.snapshot: check-toitc-env $(TOIT_SOURCE)
-	$(JAG_TOITC_PATH) -w $@ ./src/jaguar.toit
+	$(JAG_TOIT_PATH)/bin/toitc -w $@ ./src/jaguar.toit
 
 clean:
 	rm -rf $(BUILD_DIR)
 
-
 check-toitc-env:
-ifndef JAG_TOITC_PATH
-	$(error JAG_TOITC_PATH is not set)
+ifndef JAG_TOIT_PATH
+	$(error JAG_TOIT_PATH is not set)
 endif

--- a/cmd/jag/commands/config.go
+++ b/cmd/jag/commands/config.go
@@ -14,15 +14,14 @@ import (
 )
 
 const (
-	WorkspacePathEnv         = "JAG_WORKSPACE_PATH"
-	SnapshotCachePathEnv     = "JAG_SNAPSHOT_CACHE_PATH"
-	configFile               = ".jaguar"
-	ToitvmPathEnv            = "JAG_TOITVM_PATH"
-	ToitcPathEnv             = "JAG_TOITC_PATH"
-	ToitSnap2ImagePathEnv    = "JAG_TOIT_SNAP_TO_IMAGE_PATH"
-	ToitSystemMessagePathEnv = "JAG_TOIT_SYSTEM_MESSAGE_PATH"
-	// EntryPointEnv snapshot of the jaguar program
+	WorkspacePathEnv     = "JAG_WORKSPACE_PATH"
+	SnapshotCachePathEnv = "JAG_SNAPSHOT_CACHE_PATH"
+	configFile           = ".jaguar"
+
+	// EntryPointEnv snapshot of the jaguar program.
 	EntryPointEnv = "JAG_ENTRY_POINT"
+	// ToitPathEnv path to the toit sdk build.
+	ToitPathEnv = "JAG_TOIT_PATH"
 )
 
 func GetWorkspacePath() (string, error) {

--- a/cmd/jag/commands/decode.go
+++ b/cmd/jag/commands/decode.go
@@ -35,14 +35,9 @@ func DecodeCmd() *cobra.Command {
 				return err
 			}
 
-			toitvm, err := Toitvm()
+			sdk, err := GetSDK()
 			if err != nil {
 				return err
-			}
-
-			systemMessage, ok := os.LookupEnv(ToitSystemMessagePathEnv)
-			if !ok {
-				return fmt.Errorf("You must set the env variable '%s'", ToitSystemMessagePathEnv)
 			}
 
 			var snapshot string
@@ -60,7 +55,7 @@ func DecodeCmd() *cobra.Command {
 				snapshot = filepath.Join(snapshotCache, device.Name+".snapshot")
 			}
 
-			decodeCmd := toitvm.Cmd(ctx, systemMessage, snapshot, "-b", args[0])
+			decodeCmd := sdk.Toitvm(ctx, sdk.SystemMessageSnapshotPath(), snapshot, "-b", args[0])
 			decodeCmd.Stderr = os.Stderr
 			decodeCmd.Stdout = os.Stdout
 			return decodeCmd.Run()

--- a/cmd/jag/commands/run.go
+++ b/cmd/jag/commands/run.go
@@ -5,7 +5,6 @@
 package commands
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -31,19 +30,9 @@ func RunCmd() *cobra.Command {
 				return err
 			}
 
-			toitc, err := Toitc()
+			sdk, err := GetSDK()
 			if err != nil {
 				return err
-			}
-
-			toitvm, err := Toitvm()
-			if err != nil {
-				return err
-			}
-
-			toits2i, ok := os.LookupEnv(ToitSnap2ImagePathEnv)
-			if !ok {
-				return fmt.Errorf("You must set the env variable '%s'", ToitSnap2ImagePathEnv)
 			}
 
 			snapshotCache, err := GetSnapshotCachePath()
@@ -53,7 +42,7 @@ func RunCmd() *cobra.Command {
 			snapshot := filepath.Join(snapshotCache, device.Name+".snapshot")
 
 			entrypoint := args[0]
-			buildSnap := toitc.Cmd(ctx, "-w", snapshot, entrypoint)
+			buildSnap := sdk.Toitc(ctx, "-w", snapshot, entrypoint)
 			buildSnap.Stderr = os.Stderr
 			buildSnap.Stdout = os.Stdout
 			if err := buildSnap.Run(); err != nil {
@@ -72,7 +61,7 @@ func RunCmd() *cobra.Command {
 				bits = "-m64"
 			}
 
-			buildImage := toitvm.Cmd(ctx, toits2i, "--binary", bits, snapshot, image.Name())
+			buildImage := sdk.Toitvm(ctx, sdk.SnapshotToImagePath(), "--binary", bits, snapshot, image.Name())
 			buildImage.Stderr = os.Stderr
 			buildImage.Stdout = os.Stdout
 			if err := buildImage.Run(); err != nil {

--- a/cmd/jag/commands/simulate.go
+++ b/cmd/jag/commands/simulate.go
@@ -25,7 +25,7 @@ func SimulateCmd() *cobra.Command {
 				return err
 			}
 
-			toitvm, err := Toitvm()
+			sdk, err := GetSDK()
 			if err != nil {
 				return err
 			}
@@ -35,7 +35,7 @@ func SimulateCmd() *cobra.Command {
 				return fmt.Errorf("You must set the env variable '%s'", EntryPointEnv)
 			}
 
-			simCmd := toitvm.Cmd(ctx, "-b", "none", jaguarEntryPoint, strconv.Itoa(int(port)))
+			simCmd := sdk.Toitvm(ctx, "-b", "none", jaguarEntryPoint, strconv.Itoa(int(port)))
 			simCmd.Stderr = os.Stderr
 			simCmd.Stdout = os.Stdout
 			return simCmd.Run()

--- a/cmd/jag/commands/util.go
+++ b/cmd/jag/commands/util.go
@@ -5,30 +5,73 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 )
 
-type Cmd struct {
-	path string
+type SDK struct {
+	Path string
 }
 
-func (c *Cmd) Cmd(ctx context.Context, args ...string) *exec.Cmd {
-	return exec.CommandContext(ctx, c.path, args...)
-}
-
-func Toitc() (*Cmd, error) {
-	toitc, ok := os.LookupEnv(ToitcPathEnv)
+func GetSDK() (*SDK, error) {
+	toit, ok := os.LookupEnv(ToitPathEnv)
 	if !ok {
-		return nil, fmt.Errorf("You must set the env variable '%s'", ToitcPathEnv)
+		return nil, fmt.Errorf("You must set the env variable '%s'", ToitPathEnv)
 	}
 
-	return &Cmd{path: toitc}, nil
+	res := &SDK{
+		Path: toit,
+	}
+	return res, res.validate()
 }
 
-func Toitvm() (*Cmd, error) {
-	toitvm, ok := os.LookupEnv(ToitvmPathEnv)
-	if !ok {
-		return nil, fmt.Errorf("You must set the env variable '%s'", ToitvmPathEnv)
+func executable(str string) string {
+	if runtime.GOOS == "windows" {
+		return str + ".exe"
 	}
+	return str
+}
 
-	return &Cmd{path: toitvm}, nil
+func (s *SDK) ToitcPath() string {
+	return filepath.Join(s.Path, "bin", executable("toitc"))
+}
+
+func (s *SDK) ToitvmPath() string {
+	return filepath.Join(s.Path, "bin", executable("toitvm"))
+}
+
+func (s *SDK) SystemMessageSnapshotPath() string {
+	return filepath.Join(s.Path, "snapshots", "system_message.snapshot")
+}
+
+func (s *SDK) SnapshotToImagePath() string {
+	return filepath.Join(s.Path, "snapshots", "snapshot_to_image.snapshot")
+}
+
+func (s *SDK) validate() error {
+	paths := []string{
+		s.ToitcPath(),
+		s.ToitvmPath(),
+		s.SystemMessageSnapshotPath(),
+		s.SnapshotToImagePath(),
+	}
+	for _, p := range paths {
+		if stat, err := os.Stat(p); err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("invalid toit SDK, missing '%s'", p)
+			}
+			return fmt.Errorf("invalid toit SDK, failed to load '%s', reason: %w", p, err)
+		} else if stat.IsDir() {
+			return fmt.Errorf("invalid toit SDK, '%s' was a directory", p)
+		}
+	}
+	return nil
+}
+
+func (s *SDK) Toitc(ctx context.Context, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, s.ToitcPath(), args...)
+}
+
+func (s *SDK) Toitvm(ctx context.Context, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, s.ToitvmPath(), args...)
 }


### PR DESCRIPTION
Cleanup all the pathing. We now only need the `JAG_TOIT_PATH` to point to a toit sdk directory.