### PR TITLE
added 'jag version' and trimmed build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,24 @@ THIRD_PARTY_TOIT_PATH = $(CURR_DIR)/third_party/toit
 TOIT_REPO_PATH ?= $(THIRD_PARTY_TOIT_PATH)
 JAG_TOIT_PATH ?= $(TOIT_REPO_PATH)/build/host/sdk
 
+BUILD_DATE = $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+BUILD_VERSION ?= $(shell ./tools/gitversion)
+BUILD_SDK_VERSION = $(shell cd ./third_party/toit; ./../../tools/gitversion)
+
 .PHONY: jag
 jag: $(BUILD_DIR)/jag
 
 $(BUILD_DIR):
 	mkdir -p $@
 
+update_jag_info: $(BUILD_DIR)
+	sed 's/date       = .*/date       = "$(BUILD_DATE)"/' $(CURR_DIR)/cmd/jag/main.go | \
+	sed 's/version    = .*/version    = "$(BUILD_VERSION)"/' | \
+	sed 's/sdkVersion = .*/sdkVersion = "$(BUILD_SDK_VERSION)"/' > $(BUILD_DIR)/new_main.go
+	mv $(BUILD_DIR)/new_main.go $(CURR_DIR)/cmd/jag/main.go
+
 $(BUILD_DIR)/jag: $(GO_SOURCE) $(BUILD_DIR)
-	CGO_ENABLED=1 GODEBUG=netdns=go go build  -o $@ ./cmd/jag
+	CGO_ENABLED=1 GODEBUG=netdns=go go build -o $@ ./cmd/jag
 
 .PHONY: snapshot
 snapshot: $(BUILD_DIR)/jaguar.snapshot

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ jag: $(BUILD_DIR)/jag
 $(BUILD_DIR):
 	mkdir -p $@
 
-update_jag_info: $(BUILD_DIR)
+.PHONY: update-jag-info
+update-jag-info: $(BUILD_DIR)
 	sed 's/date       = .*/date       = "$(BUILD_DATE)"/' $(CURR_DIR)/cmd/jag/main.go | \
 	sed 's/version    = .*/version    = "$(BUILD_VERSION)"/' | \
 	sed 's/sdkVersion = .*/sdkVersion = "$(BUILD_SDK_VERSION)"/' > $(BUILD_DIR)/new_main.go
@@ -55,8 +56,8 @@ $(TOIT_REPO_PATH)/build/host/esp32/: $(TOIT_SOURCE) .packages
 $(BUILD_DIR)/image.snapshot: $(TOIT_REPO_PATH)/build/host/esp32/ .packages
 	cp $(TOIT_REPO_PATH)/build/snapshot $@
 
-.PHONY: image_snapshot
-image_snapshot: $(BUILD_DIR)/image.snapshot
+.PHONY: image-snapshot
+image-snapshot: $(BUILD_DIR)/image.snapshot
 
 $(BUILD_DIR)/image/:
 	mkdir -p $@

--- a/cmd/jag/commands/jag.go
+++ b/cmd/jag/commands/jag.go
@@ -6,7 +6,13 @@ package commands
 
 import "github.com/spf13/cobra"
 
-func JagCmd() *cobra.Command {
+type Info struct {
+	Version    string
+	Date       string
+	SDKVersion string
+}
+
+func JagCmd(info Info) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "jag",
 		Short: "Fast development for your ESP32",
@@ -23,10 +29,11 @@ func JagCmd() *cobra.Command {
 		RunCmd(),
 		SimulateCmd(),
 		DecodeCmd(),
-		SetupCmd(),
+		SetupCmd(info),
 		FlashCmd(),
 		MonitorCmd(),
 		SetPortCmd(),
+		VersionCmd(info),
 	)
 	return cmd
 }

--- a/cmd/jag/commands/setup.go
+++ b/cmd/jag/commands/setup.go
@@ -25,11 +25,11 @@ func getToitSDKURL(version string) string {
 }
 
 func getSnapshotURL(version string) string {
-	return fmt.Sprintf("https://github.com/toitlang/jaguar/releases/download/sdk-%s/jaguar.snapshot", version)
+	return fmt.Sprintf("https://github.com/toitlang/jaguar/releases/download/%s/jaguar.snapshot", version)
 }
 
 func getESP32ImageURL(version string) string {
-	return fmt.Sprintf("https://github.com/toitlang/jaguar/releases/download/sdk-%s/image.tar.gz", version)
+	return fmt.Sprintf("https://github.com/toitlang/jaguar/releases/download/%s/image.tar.gz", version)
 }
 
 func getEsptoolURL(version string) string {
@@ -37,10 +37,14 @@ func getEsptoolURL(version string) string {
 	if currOS == "darwin" {
 		currOS = "macos"
 	}
-	return executable(fmt.Sprintf("https://github.com/toitlang/jaguar/releases/download/sdk-%s/esptool_%s_v3.0", version, currOS))
+	return executable(fmt.Sprintf("https://github.com/toitlang/jaguar/releases/download/esptool-%s/esptool_%s_%s", version, currOS, version))
 }
 
-func SetupCmd() *cobra.Command {
+const (
+	esptoolVersion = "v3.0"
+)
+
+func SetupCmd(info Info) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "setup",
 		Short: "Setup the Toit SDK",
@@ -48,34 +52,29 @@ func SetupCmd() *cobra.Command {
 			"The downloaded SDK is stored locally in a subdirectory of your home folder.",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			version, err := cmd.Flags().GetString("version")
-			if err != nil {
-				return err
-			}
 			ctx := cmd.Context()
-			if err := downloadSDK(ctx, version); err != nil {
+			if err := downloadSDK(ctx, info.SDKVersion); err != nil {
 				return err
 			}
 
-			if err := downloadESP32Image(ctx, version); err != nil {
+			if err := downloadESP32Image(ctx, info.Version); err != nil {
 				return err
 			}
 
-			if err := downloadSnapshot(ctx, version); err != nil {
+			if err := downloadSnapshot(ctx, info.Version); err != nil {
 				return err
 			}
 
-			if err := downloadEsptool(ctx, version); err != nil {
+			if err := downloadEsptool(ctx, esptoolVersion); err != nil {
 				return err
 			}
 
-			fmt.Printf("Successfully setup Jaguar with Toit SDK %s.\n", version)
+			fmt.Printf("Successfully setup Jaguar %s with Toit SDK %s.\n", info.Version, info.SDKVersion)
 
 			return nil
 		},
 	}
 
-	cmd.Flags().StringP("version", "v", "v0.10.0", "Toit SDK version to download")
 	return cmd
 }
 

--- a/cmd/jag/commands/util.go
+++ b/cmd/jag/commands/util.go
@@ -1,3 +1,7 @@
+// Copyright (C) 2021 Toitware ApS. All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
 package commands
 
 import (

--- a/cmd/jag/commands/version.go
+++ b/cmd/jag/commands/version.go
@@ -1,0 +1,26 @@
+// Copyright (C) 2021 Toitware ApS. All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func VersionCmd(info Info) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "version",
+		Short:        "Prints the version of jaguar",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("Version:\t", info.Version)
+			fmt.Println("SDK Version:\t", info.SDKVersion)
+			fmt.Println("Build date:\t", info.Date)
+		},
+	}
+	return cmd
+}

--- a/cmd/jag/commands/version.go
+++ b/cmd/jag/commands/version.go
@@ -18,7 +18,7 @@ func VersionCmd(info Info) *cobra.Command {
 		SilenceUsage: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println("Version:\t", info.Version)
-			fmt.Println("SDK Version:\t", info.SDKVersion)
+			fmt.Println("SDK version:\t", info.SDKVersion)
 			fmt.Println("Build date:\t", info.Date)
 		},
 	}

--- a/cmd/jag/main.go
+++ b/cmd/jag/main.go
@@ -6,6 +6,16 @@ package main
 
 import "github.com/toitlang/jaguar/cmd/jag/commands"
 
+var (
+	date       = "2021-12-14T11:04:27Z"
+	version    = "v0.0.5"
+	sdkVersion = "v0.10.0"
+)
+
 func main() {
-	commands.JagCmd().Execute()
+	commands.JagCmd(commands.Info{
+		Date:       date,
+		Version:    version,
+		SDKVersion: sdkVersion,
+	}).Execute()
 }

--- a/cmd/jag/main.go
+++ b/cmd/jag/main.go
@@ -7,7 +7,7 @@ package main
 import "github.com/toitlang/jaguar/cmd/jag/commands"
 
 var (
-	date       = "2021-12-14T11:04:27Z"
+	date       = "2021-12-14T12:28:00Z"
 	version    = "v0.0.5"
 	sdkVersion = "v0.10.0"
 )

--- a/tools/gitversion
+++ b/tools/gitversion
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# Copyright (C) 2021 Toitware ApS. All rights reserved.
+# Use of this source code is governed by an MIT-style license that can be
+# found in the LICENSE file.
+
 set -e
 
 # Make sure git is installed and we are in a git tree.

--- a/tools/gitversion
+++ b/tools/gitversion
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+
+# Make sure git is installed and we are in a git tree.
+command -v git >/dev/null                       || { echo "UNKNOWN"; exit 0; }
+git rev-parse --is-inside-work-tree &>/dev/null || { echo "UNKNOWN"; exit 0; }
+
+
+CURRENT_COMMIT=$(git rev-parse HEAD)
+CURRENT_COMMIT_SHORT=$(git rev-parse --short HEAD)
+LATEST_VERSION_TAG=$(git describe --tags --match "v[0-9]*" --abbrev=0 `git rev-list --tags --max-count=1` 2>/dev/null || echo "")
+
+if [ "$LATEST_VERSION_TAG" != "" ]; then
+  VERSION_TAG_COMMIT=$(git rev-parse $LATEST_VERSION_TAG^{})
+  CURRENT_COMMIT_NO=$(git rev-list --count HEAD ^$VERSION_TAG_COMMIT)
+else
+  LATEST_VERSION_TAG="v0.0.0"
+  VERSION_TAG_COMMIT="UNKNOWN"
+  CURRENT_COMMIT_NO=$(git rev-list --count HEAD)
+fi
+
+if [ "$VERSION_TAG_COMMIT" == "$CURRENT_COMMIT" ]; then
+    # Always use the tag if the current commit is the tag.
+    echo "$LATEST_VERSION_TAG"
+else
+    echo "$CURRENT_COMMIT_SHORT"
+fi

--- a/tools/prepare_release.sh
+++ b/tools/prepare_release.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# Copyright (C) 2021 Toitware ApS. All rights reserved.
+# Use of this source code is governed by an MIT-style license that can be
+# found in the LICENSE file.
+
 set -e
 
 CURR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
@@ -6,7 +11,7 @@ CURR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 VERSION=$1
 echo "Updating cmd/jag/main.go"
 if [[ "$VERSION" == "" ]]; then
-    make -C $CURR_DIR/../ update_jag_info
+    make -C $CURR_DIR/../ update-jag-info
 else
-    BUILD_VERSION=$VERSION make -C $CURR_DIR/../ update_jag_info
+    BUILD_VERSION=$VERSION make -C $CURR_DIR/../ update-jag-info
 fi

--- a/tools/prepare_release.sh
+++ b/tools/prepare_release.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+CURR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+VERSION=$1
+echo "Updating cmd/jag/main.go"
+if [[ "$VERSION" == "" ]]; then
+    make -C $CURR_DIR/../ update_jag_info
+else
+    BUILD_VERSION=$VERSION make -C $CURR_DIR/../ update_jag_info
+fi


### PR DESCRIPTION
Before each release we have to run: `./tools/prepare_release.sh <version>`.
That will update `main.go` with the right values.