### PR TITLE
Let 'jag watch' use the compiler to find dependent files

### DIFF
--- a/cmd/jag/commands/watch.go
+++ b/cmd/jag/commands/watch.go
@@ -5,10 +5,14 @@
 package commands
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"fmt"
-	"log"
 	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/cobra"
@@ -16,9 +20,9 @@ import (
 
 func WatchCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "watch <directory> <entrypoint>",
-		Short:        "watches <directory> for changes and runs <entrypoint> on the device every time",
-		Args:         cobra.ExactArgs(2),
+		Use:          "watch <entrypoint>",
+		Short:        "watches for changes on <entrypoint> and dependencies and starts a run every time changes happens",
+		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := GetConfig()
@@ -37,17 +41,7 @@ func WatchCmd() *cobra.Command {
 				return err
 			}
 
-			directory := args[0]
-			if stat, err := os.Stat(directory); err != nil {
-				if os.IsNotExist(err) {
-					return fmt.Errorf("the directory '%s' did not exists", directory)
-				}
-				return fmt.Errorf("could not stat directory '%s', reason: %w", directory, err)
-			} else if !stat.IsDir() {
-				return fmt.Errorf("the path given '%s' was not a directory", directory)
-			}
-
-			entrypoint := args[1]
+			entrypoint := args[0]
 			if stat, err := os.Stat(entrypoint); err != nil {
 				if os.IsNotExist(err) {
 					return fmt.Errorf("the entrypoint '%s' did not exists", entrypoint)
@@ -57,7 +51,7 @@ func WatchCmd() *cobra.Command {
 				return fmt.Errorf("the path given '%s' was a directory", entrypoint)
 			}
 
-			watcher, err := fsnotify.NewWatcher()
+			watcher, err := newWatcher()
 			if err != nil {
 				return err
 			}
@@ -65,10 +59,6 @@ func WatchCmd() *cobra.Command {
 
 			waitCh, fn := onWatchChanges(ctx, watcher, device, sdk, entrypoint)
 			go fn()
-
-			if err := watcher.Add(directory); err != nil {
-				return fmt.Errorf("failed to watch directory: '%s', reason: %w", directory, err)
-			}
 
 			<-waitCh
 			return nil
@@ -78,8 +68,141 @@ func WatchCmd() *cobra.Command {
 	return cmd
 }
 
-func onWatchChanges(ctx context.Context, watcher *fsnotify.Watcher, device *Device, sdk *SDK, entrypoint string) (<-chan struct{}, func()) {
+type watcher struct {
+	sync.Mutex
+	watcher *fsnotify.Watcher
+
+	paths map[string]struct{}
+}
+
+func newWatcher() (*watcher, error) {
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	return &watcher{
+		watcher: w,
+		paths:   map[string]struct{}{},
+	}, nil
+}
+
+func (w *watcher) Close() error {
+	return w.Close()
+}
+
+func (w *watcher) Events() chan fsnotify.Event {
+	return w.watcher.Events
+}
+
+func (w *watcher) Errors() chan error {
+	return w.watcher.Errors
+}
+
+func (w *watcher) Watch(paths ...string) (err error) {
+	for i, p := range paths {
+		if paths[i], err = filepath.EvalSymlinks(p); err != nil {
+			return err
+		}
+	}
+
+	paths = findParents(paths...)
+	fmt.Println("Watching paths: ", paths)
+	candidates := map[string]struct{}{}
+	for _, p := range paths {
+		if _, ok := w.paths[p]; !ok {
+			w.Mutex.Lock()
+			fmt.Println("watch path", p)
+			w.watcher.Add(p)
+			w.paths[p] = struct{}{}
+			w.Mutex.Unlock()
+		}
+		candidates[p] = struct{}{}
+	}
+
+	for p := range w.paths {
+		if _, ok := candidates[p]; !ok {
+			w.Mutex.Lock()
+			fmt.Println("remove path", p)
+			w.watcher.Remove(p)
+			delete(w.paths, p)
+			w.Mutex.Unlock()
+		}
+	}
+	return nil
+}
+
+func findParents(paths ...string) []string {
+	var res []string
+	for _, p := range paths {
+		if len(res) == 0 {
+			res = append(res, p)
+			continue
+		}
+
+		matched := false
+		for i, r := range res {
+			fmt.Printf("Is %s sub of %s: %v\n", r, p, isSub(r, p))
+			if isSub(r, p) {
+				matched = true
+				break
+			}
+			fmt.Printf("Is %s sub of %s: %v\n", p, r, isSub(p, r))
+			if isSub(p, r) {
+				matched = true
+				res[i] = p
+				break
+			}
+		}
+		if !matched {
+			res = append(res, p)
+		}
+	}
+	return res
+}
+
+func isSub(parent, sub string) bool {
+	if parent == sub {
+		return true
+	}
+	pattern := parent + string(filepath.Separator) + "*"
+	if ok, err := filepath.Match(pattern, sub); err == nil && ok {
+		return true
+	}
+	return false
+}
+
+func parseDependeniesToDirs(b []byte) []string {
+	m := map[string]struct{}{}
+	scanner := bufio.NewScanner(bytes.NewReader(b))
+	for scanner.Scan() {
+		p := strings.TrimSuffix(strings.TrimSpace(scanner.Text()), ":")
+		m[filepath.Dir(p)] = struct{}{}
+	}
+	var res []string
+	for r := range m {
+		res = append(res, r)
+	}
+	return res
+}
+
+func onWatchChanges(ctx context.Context, watcher *watcher, device *Device, sdk *SDK, entrypoint string) (<-chan struct{}, func()) {
 	doneCh := make(chan struct{})
+
+	updateWatcher := func(runCtx context.Context) {
+		cmd := sdk.Toitc(ctx, "--dependency-file", "-", "--dependency-format", "plain", "--analyze", entrypoint)
+		o, err := cmd.CombinedOutput()
+		var paths []string
+		if err != nil {
+			fmt.Printf("Failed to get dependencies for entrypoint: '%s', reason: %v\n", entrypoint, err)
+			paths = []string{filepath.Dir(entrypoint)}
+		} else {
+			paths = parseDependeniesToDirs(o)
+		}
+
+		if err := watcher.Watch(paths...); err != nil {
+			fmt.Println("Failed to update watcher: ", err)
+		}
+	}
 
 	runOnDevice := func(runCtx context.Context) {
 		fmt.Println("Compiling...")
@@ -95,29 +218,30 @@ func onWatchChanges(ctx context.Context, watcher *fsnotify.Watcher, device *Devi
 		fmt.Println("Successfully pushed program to device.")
 	}
 
-	runOnDevice(ctx)
+	firstCtx, previousCancel := context.WithCancel(ctx)
+	go updateWatcher(firstCtx)
+	runOnDevice(firstCtx)
 	return doneCh, func() {
 		defer close(doneCh)
-		var previousCancel context.CancelFunc
-		previousCancel = func() {}
 		for {
-			previousCancel()
-			var innerCtx context.Context
-			innerCtx, previousCancel = context.WithCancel(ctx)
 			select {
-			case event, ok := <-watcher.Events:
+			case event, ok := <-watcher.Events():
 				if !ok {
 					return
 				}
 				if event.Op&fsnotify.Write == fsnotify.Write {
-					log.Printf("File modified '%s'\n", event.Name)
+					previousCancel()
+					var innerCtx context.Context
+					innerCtx, previousCancel = context.WithCancel(ctx)
+					fmt.Printf("File modified '%s'\n", event.Name)
+					go updateWatcher(innerCtx)
 					runOnDevice(innerCtx)
 				}
-			case err, ok := <-watcher.Errors:
+			case err, ok := <-watcher.Errors():
 				if !ok {
 					return
 				}
-				log.Println("error:", err)
+				fmt.Println("watch error:", err)
 			case <-ctx.Done():
 				return
 			}

--- a/cmd/jag/commands/watch.go
+++ b/cmd/jag/commands/watch.go
@@ -141,13 +141,13 @@ func findParents(paths ...string) []string {
 
 		matched := false
 		for i, r := range res {
-			fmt.Printf("Is %s sub of %s: %v\n", r, p, isSub(r, p))
-			if isSub(r, p) {
+			fmt.Printf("Is %s sub of %s: %v\n", r, p, isSubPath(r, p))
+			if isSubPath(r, p) {
 				matched = true
 				break
 			}
-			fmt.Printf("Is %s sub of %s: %v\n", p, r, isSub(p, r))
-			if isSub(p, r) {
+			fmt.Printf("Is %s sub of %s: %v\n", p, r, isSubPath(p, r))
+			if isSubPath(p, r) {
 				matched = true
 				res[i] = p
 				break
@@ -160,13 +160,23 @@ func findParents(paths ...string) []string {
 	return res
 }
 
-func isSub(parent, sub string) bool {
+func isSubPath(parent, sub string) bool {
 	if parent == sub {
 		return true
 	}
-	pattern := parent + string(filepath.Separator) + "*"
-	if ok, err := filepath.Match(pattern, sub); err == nil && ok {
-		return true
+	if rel, err := filepath.Rel(sub, parent); err == nil {
+		prefix := ".." + string(filepath.Separator)
+		for {
+			if rel == ".." {
+				return true
+			}
+			if strings.HasPrefix(rel, prefix) {
+				rel = strings.TrimPrefix(rel, prefix)
+			} else {
+				return false
+			}
+		}
+		return rel == ".." || strings.TrimLeft(rel, ".."+string(filepath.Separator)) == ""
 	}
 	return false
 }

--- a/cmd/jag/commands/watch.go
+++ b/cmd/jag/commands/watch.go
@@ -106,7 +106,8 @@ func (w *watcher) Watch(paths ...string) (err error) {
 		}
 	}
 
-	paths = findParents(paths...)
+	// TODO: Watch does not work for sub-sub directories so we disable this for now.
+	// paths = findParents(paths...)
 	candidates := map[string]struct{}{}
 	for _, p := range paths {
 		if _, ok := w.paths[p]; !ok {


### PR DESCRIPTION
note: `findParents` may in some scenarios have too many paths.