### PR TITLE
Minor tweaks to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Jaguar: Live reloading for your ESP32
 
 Jaguar enables live reloading when developing for the ESP32. Develop, update, and restart 
@@ -25,6 +24,8 @@ program, we stop any old version of the program and free the resources it has co
 version of the program gets to start again from `main`.
 
 ## How do I use it?
+
+([See below if you'd rather build it yourself from source.](#building-it-yourself))
 
 Start by downloading and installing the `jag` binary for your host platform:
 
@@ -135,21 +136,21 @@ Let's assume your git clones can be referenced like this:
 
 ``` sh
 export TOIT_PATH=<path to https://github.com/toitlang/toit clone>
-export JAGUAR_PATH=<path to https://github.com/toitlang/jaguar clone>
+export JAG_PATH=<path to https://github.com/toitlang/jaguar clone>
 ```
 
 Now start with flashing the Jaguar application onto your ESP32. This is easily doable from
 within the `$TOIT_PATH` directory:
 
 ``` sh
-$TOIT_PATH/build/host/sdk/bin/toitpkg pkg install --project-root=$JAGUAR_PATH
-make flash ESP32_ENTRY=$JAGUAR_PATH/src/jaguar.toit \
+$TOIT_PATH/build/host/sdk/bin/toitpkg pkg install --project-root=$JAG_PATH
+make flash ESP32_ENTRY=$JAG_PATH/src/jaguar.toit \
   ESP32_PORT=/dev/ttyUSB0 \
   ESP32_WIFI_SSID="<ssid>" \
   ESP32_WIFI_PASSWORD="<password>"
 ```
 
-For building Jaguar, all you need to do is run from within your `$JAGUAR_PATH` directory:
+For building Jaguar, all you need to do is run from within your `$JAG_PATH` directory:
 
 ``` sh
 make

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Now start with flashing the Jaguar application onto your ESP32. This is easily d
 within the `$TOIT_PATH` directory:
 
 ``` sh
-$TOIT_PATH/build/host/sdk/bin/toitpkg pkg install --project-root=$JAG_PATH
+$TOIT_PATH/build/host/sdk/bin/toit.pkg pkg install --project-root=$JAG_PATH
 make flash ESP32_ENTRY=$JAG_PATH/src/jaguar.toit \
   ESP32_PORT=/dev/ttyUSB0 \
   ESP32_WIFI_SSID="<ssid>" \

--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ version of the program gets to start again from `main`.
 
 ## How do I use it?
 
-([See below if you'd rather build it yourself from source.](#building-it-yourself))
-
-Start by downloading and installing the `jag` binary for your host platform:
+Unless you want to [build Jaguar from source](#building-it-yourself), start by
+downloading and installing the `jag` binary for your host platform:
 
 - [Download Jaguar for Windows](https://github.com/toitlang/jaguar/releases/latest/download/jag_installer.exe)
   (or as an [archive](https://github.com/toitlang/jaguar/releases/latest/download/jag_windows.zip))


### PR DESCRIPTION
Changed the environment variable JAGUAR_PATH to JAG_PATH.
This doesn't seem to be used anywhere, only in the README,
so I don't think it needs updating anywhere else.  The change
makes us consistent in using JAG_ as a prefix for environment
variables.

Put in a pointer from the top to the bottom of the README for those
that would rather build their own open source projects, rather than
download binaries.