### PR TITLE
Added 'jag checkout <url>' to checkout repository to run

### DIFF
--- a/cmd/jag/commands/checkout.go
+++ b/cmd/jag/commands/checkout.go
@@ -90,7 +90,7 @@ func checkout(ctx context.Context, url string, cwd string) (string, error) {
 		return "", err
 	}
 
-	return exampleDirectory, nil
+	return filepath.Join(repoPath, proj.File), nil
 }
 
 type Repository struct {
@@ -102,6 +102,10 @@ type Repository struct {
 
 func (r *Repository) Name() string {
 	return strings.TrimSuffix(path.Base(r.File), path.Ext(r.File))
+}
+
+func isRepoURL(url string) bool {
+	return githubRegexp.MatchString(url) || bitbucketRegexp.MatchString(url) || gitlabRegexp.MatchString(url)
 }
 
 func parseURL(url string) (*Repository, error) {

--- a/cmd/jag/commands/checkout.go
+++ b/cmd/jag/commands/checkout.go
@@ -1,0 +1,131 @@
+// Copyright (C) 2021 Toitware ApS. All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/spf13/cobra"
+)
+
+var (
+	githubRegexp    = regexp.MustCompile("^(https?://)?github.com/([^/]+)/([^/]+)/blob/([^/]+)/(.+)$")
+	gitlabRegexp    = regexp.MustCompile("^(https?://)?([^/]+)/([^/]+)/([^/]+)/-/blob/([^/]+)/(.+)$")
+	bitbucketRegexp = regexp.MustCompile("^(https?://)?bitbucket.org/([^/]+)/([^/]+)/src/([^/]+)/(.+)$")
+)
+
+func CheckoutCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "checkout <url to entrypoint>",
+		Short:        "Checkout a repository or example",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			url := args[0]
+			if _, err := checkout(url, cwd); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func checkout(url string, cwd string) (string, error) {
+	proj, err := parseURL(url)
+	if err != nil {
+		return "", err
+	}
+
+	path := filepath.Join(cwd, proj.Project)
+	fmt.Printf("Downloading %s into %s\n", proj.URL, proj.Project)
+	_, err = git.PlainClone(path, false, &git.CloneOptions{
+		URL:           proj.URL,
+		ReferenceName: plumbing.NewBranchReferenceName(proj.Branch),
+		Progress:      os.Stdout,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to clone repository, reason: %w", err)
+	}
+
+	return proj.Project, nil
+}
+
+type Repository struct {
+	Project string
+	File    string
+	URL     string
+	Branch  string
+}
+
+func parseURL(url string) (*Repository, error) {
+	if githubRegexp.MatchString(url) {
+		return parseGithub(url)
+	}
+	if bitbucketRegexp.MatchString(url) {
+		return parseBitbucket(url)
+	}
+
+	if gitlabRegexp.MatchString(url) {
+		return parseGitlab(url)
+	}
+
+	return nil, fmt.Errorf("Could not parse the repository URL: '%s'", url)
+}
+
+func parseGithub(url string) (*Repository, error) {
+	matches := githubRegexp.FindStringSubmatch(url)
+
+	if len(matches) != 6 {
+		return nil, fmt.Errorf("URL: '%s' was not a github path", url)
+	}
+
+	return &Repository{
+		File:    matches[5],
+		Project: matches[3],
+		URL:     fmt.Sprintf("https://github.com/%s/%s", matches[2], matches[3]),
+		Branch:  matches[4],
+	}, nil
+}
+
+func parseGitlab(url string) (*Repository, error) {
+	matches := gitlabRegexp.FindStringSubmatch(url)
+
+	if len(matches) != 7 {
+		return nil, fmt.Errorf("URL: '%s' was not a gitlab path", url)
+	}
+
+	return &Repository{
+		File:    matches[6],
+		Project: matches[4],
+		URL:     fmt.Sprintf("https://%s/%s/%s", matches[2], matches[3], matches[4]),
+		Branch:  matches[5],
+	}, nil
+}
+
+func parseBitbucket(url string) (*Repository, error) {
+	matches := bitbucketRegexp.FindStringSubmatch(url)
+
+	if len(matches) != 6 {
+		return nil, fmt.Errorf("URL: '%s' was not a bitbucket path", url)
+	}
+
+	return &Repository{
+		File:    matches[5],
+		Project: matches[3],
+		URL:     fmt.Sprintf("https://bitbucket.org/%s/%s", matches[2], matches[3]),
+		Branch:  matches[4],
+	}, nil
+}

--- a/cmd/jag/commands/checkout_test.go
+++ b/cmd/jag/commands/checkout_test.go
@@ -1,0 +1,125 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_parseGithub(t *testing.T) {
+	tests := []struct {
+		in   string
+		repo *Repository
+	}{
+		{in: "foo"},
+		{
+			in: "https://github.com/toitlang/toit/blob/master/examples/hello.toit",
+			repo: &Repository{
+				File:    "examples/hello.toit",
+				Project: "toit",
+				URL:     "https://github.com/toitlang/toit",
+				Branch:  "master",
+			},
+		},
+		{
+			in: "github.com/toitlang/toit/blob/foo/examples/hello.toit",
+			repo: &Repository{
+				File:    "examples/hello.toit",
+				Project: "toit",
+				URL:     "https://github.com/toitlang/toit",
+				Branch:  "foo",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.in, func(t *testing.T) {
+			res, err := parseGithub(test.in)
+			if test.repo == nil {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.repo, res)
+			}
+		})
+	}
+}
+
+func Test_parseGitlab(t *testing.T) {
+	tests := []struct {
+		in   string
+		repo *Repository
+	}{
+		{in: "foo"},
+		{
+			in: "https://gitlab.matrix.org/matrix-org/olm/-/blob/wip-clang-format/lib/curve25519-donna.h",
+			repo: &Repository{
+				File:    "lib/curve25519-donna.h",
+				Project: "olm",
+				URL:     "https://gitlab.matrix.org/matrix-org/olm",
+				Branch:  "wip-clang-format",
+			},
+		},
+		{
+			in: "https://gitlab.com/gitlab-org/gitlab/-/blob/master/.eslintrc.yml",
+			repo: &Repository{
+				File:    ".eslintrc.yml",
+				Project: "gitlab",
+				URL:     "https://gitlab.com/gitlab-org/gitlab",
+				Branch:  "master",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.in, func(t *testing.T) {
+			res, err := parseGitlab(test.in)
+			if test.repo == nil {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.repo, res)
+			}
+		})
+	}
+}
+
+func Test_parseBitbucket(t *testing.T) {
+	tests := []struct {
+		in   string
+		repo *Repository
+	}{
+		{in: "foo"},
+		{
+			in: "https://bitbucket.org/toitlang/toit/src/master/examples/hello.toit",
+			repo: &Repository{
+				File:    "examples/hello.toit",
+				Project: "toit",
+				URL:     "https://bitbucket.org/toitlang/toit",
+				Branch:  "master",
+			},
+		},
+		{
+			in: "bitbucket.org/toitlang/toit/src/foo/examples/hello.toit",
+			repo: &Repository{
+				File:    "examples/hello.toit",
+				Project: "toit",
+				URL:     "https://bitbucket.org/toitlang/toit",
+				Branch:  "foo",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.in, func(t *testing.T) {
+			res, err := parseBitbucket(test.in)
+			if test.repo == nil {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.repo, res)
+			}
+		})
+	}
+}

--- a/cmd/jag/commands/jag.go
+++ b/cmd/jag/commands/jag.go
@@ -75,6 +75,7 @@ func JagCmd(info Info) *cobra.Command {
 		PkgCmd(info, analyticsClient),
 		ConfigCmd(),
 		VersionCmd(info),
+		CheckoutCmd(),
 	)
 	return cmd
 }

--- a/cmd/jag/commands/run.go
+++ b/cmd/jag/commands/run.go
@@ -22,12 +22,23 @@ func RunCmd() *cobra.Command {
 		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			cfg, err := directory.GetWorkspaceConfig()
 			if err != nil {
 				return err
 			}
 
 			entrypoint := args[0]
+			if isRepoURL(entrypoint) {
+				cwd, err := os.Getwd()
+				if err != nil {
+					return err
+				}
+				if entrypoint, err = checkout(ctx, entrypoint, cwd); err != nil {
+					return err
+				}
+			}
+
 			if stat, err := os.Stat(entrypoint); err != nil {
 				if os.IsNotExist(err) {
 					return fmt.Errorf("no such file or directory: '%s'", entrypoint)
@@ -37,7 +48,6 @@ func RunCmd() *cobra.Command {
 				return fmt.Errorf("can't run directory: '%s'", entrypoint)
 			}
 
-			ctx := cmd.Context()
 			deviceSelect, err := parseDeviceFlag(cmd)
 			if err != nil {
 				return err

--- a/go.mod
+++ b/go.mod
@@ -8,15 +8,17 @@ require (
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/cheggaaa/pb/v3 v3.0.8
 	github.com/fsnotify/fsnotify v1.5.1
+	github.com/go-git/go-git/v5 v5.4.2
 	github.com/google/uuid v1.3.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/segmentio/backo-go v1.0.0 // indirect
 	github.com/spf13/viper v1.9.0
+	github.com/stretchr/testify v1.7.0
 	github.com/toitlang/tpkg v0.0.0-20211220115217-4c19b222e14a
-	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
+	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c
 	go.bug.st/serial v1.3.3
 	golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b
 	golang.org/x/sys v0.0.0-20211213223007-03aa0b5f6827 // indirect
 	gopkg.in/segmentio/analytics-go.v3 v3.1.0
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 )


### PR DESCRIPTION
```
jag checkout https://github.com/toitlang/toit/blob/master/examples/ntp/ntp.toit
Downloading https://github.com/toitlang/toit into ntp
Enumerating objects: 4329, done.
Counting objects: 100% (4329/4329), done.
Compressing objects: 100% (2695/2695), done.
Total 4329 (delta 1540), reused 4213 (delta 1488), pack-reused 0
Installing toit dependencies in ntp/examples/ntp
```