### PR TITLE
Fix Windows installer.

### DIFF
--- a/tools/windows_installer/build.bat
+++ b/tools/windows_installer/build.bat
@@ -1,4 +1,4 @@
-set VERSION=%1
+set TOIT_VERSION=%1
 set BIN_PATH=%2
 set BUILD_DIRECTORY=%3
 

--- a/tools/windows_installer/installer.iss
+++ b/tools/windows_installer/installer.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Jaguar"
-#define MyAppPublisher "(c) 2021 Toitware ApS"
+#define MyAppPublisher "Toitware ApS"
 #define MyAppURL "https://www.toitlang.org"
 
 [Setup]


### PR DESCRIPTION
As pointed out on https://github.com/microsoft/winget-pkgs/pull/45622:
The Publisher shouldn't have a copyright in it.
The version was missing.