### PR TITLE
Set only one env variable for the Toit repository.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,9 @@ jobs:
 
       - name: Build jag
         run: |
-          GOOS=linux JAG_BINARY=linux/jag make jag
-          GOOS=darwin JAG_BINARY=macos/jag make jag
-          GOOS=windows JAG_BINARY=windows/jag.exe make jag
+          GOOS=linux make JAG_BINARY=linux/jag jag
+          GOOS=darwin make JAG_BINARY=macos/jag jag
+          GOOS=windows make JAG_BINARY=windows/jag.exe jag
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2

--- a/README.md
+++ b/README.md
@@ -160,47 +160,40 @@ implementation yourself? Great! You will need to follow the instructions for
 [building Toit](https://github.com/toitlang/toit) and make sure you can flash a
 [simple example](https://github.com/toitlang/toit/blob/master/examples/hello.toit) onto your device.
 
-Let's assume your git clones can be referenced like this:
+We assume all the commands are executed from this directory (the checkout of
+the Jaguar repository).
 
+Start by setting the `JAG_TOIT_REPO_PATH`. Typically, this would  be
+the path to the third_party directory:
 ``` sh
-export TOIT_PATH=<path to https://github.com/toitlang/toit clone>
-export JAG_PATH=<path to https://github.com/toitlang/jaguar clone>
+export JAG_TOIT_REPO_PATH=$PWD/third_party/toit
 ```
+Alternatively, `JAG_TOIT_REPO_PATH` could point to a different checkout of Toit.
 
-First, we need to build the `toit.pkg` support from the `$TOIT_PATH` directory:
-
+Setup the ESP-IDF environment variables and PATHs, which will allow to compile
+ESP32 programs. The easiest is to just use the `export.sh` that comes with
+the ESP-IDF repository:
 ``` sh
-cd $TOIT_PATH
-make sdk
+source $JAG_TOIT_REPO_PATH/third_party/esp-idf/export.sh
 ```
+Note that Toit's ESP-IDF is patched. Don't use use a plain ESP-IDF checkout instead.
 
-Now we can compile the Jaguar assets necessary for flashing Jaguar onto your
-device. This is easily doable from within the `$JAG_PATH` directory.
-
+Compile everything.
 ``` sh
-cd $JAG_PATH
-$TOIT_PATH/build/host/sdk/bin/toit.pkg install --project-root=$JAG_PATH
-source $TOIT_PATH/third_party/esp-idf/export.sh
 make
 ```
+This will build the SDK from the `JAG_TOIT_REPO_PATH`, then use it to download
+the Toit dependencies (using `toit.pkg`) and finally build Jaguar; both the
+host executable, as well as the Toit program that runs on the device.
 
-You can now flash Jaguar onto your device by telling it where to find the Toit SDK
-and the pre-built image for the Jaguar application for the ESP32:
-
-``` sh
-cd $JAG_PATH
-export JAG_TOIT_PATH=$TOIT_PATH/build/host/sdk
-export JAG_ESP32_IMAGE_PATH=$JAG_PATH/build/image
-export JAG_ESPTOOL_PATH=$IDF_PATH/components/esptool_py/esptool/esptool.py
-build/jag flash --port=/dev/ttyUSB0 --wifi-ssid="<ssid>" --wifi-password="<password>"
-```
-
-The Jaguar command-line tool in `build/jag` now uses the environment variables from above
-to find the Toit SDK, so you start using it:
+You can now use Jaguar as usual:
 
 ``` sh
-cd $JAG_PATH
-build/jag scan
+build/jag flash
+sleep 3        # Give the device time to connect to the WiFi.
+build/jag scan # Select the new device.
+build/jag run $JAG_TOIT_REPO_PATH/examples/hello.toit
+build/jag monitor
 ```
 
 ## Contributing

--- a/cmd/jag/commands/util.go
+++ b/cmd/jag/commands/util.go
@@ -32,17 +32,9 @@ type SDK struct {
 }
 
 func GetSDK(ctx context.Context) (*SDK, error) {
-	toit, ok := os.LookupEnv(directory.ToitPathEnv)
-	info := GetInfo(ctx)
-	if !ok {
-		sdkCachePath, err := directory.GetSDKCachePath()
-		if err != nil {
-			return nil, err
-		}
-		if stat, err := os.Stat(sdkCachePath); err != nil || !stat.IsDir() {
-			return nil, fmt.Errorf("no SDK found in '%s', but Jaguar %s needs version %s.\nRun 'jag setup' to fix this.", sdkCachePath, info.Version, info.SDKVersion)
-		}
-		toit = sdkCachePath
+	toit, err := directory.GetSDKPath()
+	if err != nil {
+		return nil, err
 	}
 
 	versionPath := filepath.Join(toit, "VERSION")
@@ -57,7 +49,9 @@ func GetSDK(ctx context.Context) (*SDK, error) {
 		Path:    toit,
 		Version: version,
 	}
-	return res, res.validate(info, ok)
+	info := GetInfo(ctx)
+	_, skipVersionCheck := os.LookupEnv(directory.ToitRepoPathEnv)
+	return res, res.validate(info, skipVersionCheck)
 }
 
 func (s *SDK) ToitCompilePath() string {

--- a/cmd/jag/directory/directory.go
+++ b/cmd/jag/directory/directory.go
@@ -7,6 +7,7 @@ package directory
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 
@@ -21,11 +22,7 @@ const (
 	configFile           = ".jaguar"
 
 	// ToitPathEnv: Path to the Toit SDK build.
-	ToitPathEnv = "JAG_TOIT_PATH"
-	// EsptoolPathEnv: Path to the esptool.
-	EsptoolPathEnv = "JAG_ESPTOOL_PATH"
-	// ImageEnv: Path to the Jaguar pre-built image for the ESP32.
-	Esp32ImageEnv = "JAG_ESP32_IMAGE_PATH"
+	ToitRepoPathEnv = "JAG_TOIT_REPO_PATH"
 	// WifiSSIDEnv if set will use this wifi ssid.
 	WifiSSIDEnv = "JAG_WIFI_SSID"
 	// WifiPasswordEnv if set will use this wifi password.
@@ -89,6 +86,21 @@ func GetSnapshotsCachePath() (string, error) {
 	return ensureDirectory(filepath.Join(home, ".cache", "jaguar", "snapshots"), nil)
 }
 
+func GetSDKPath() (string, error) {
+	toit_repo_path, ok := os.LookupEnv(ToitRepoPathEnv)
+	if ok {
+		return filepath.Join(toit_repo_path, "build", "host", "sdk"), nil
+	}
+	sdkCachePath, err := GetSDKCachePath()
+	if err != nil {
+		return "", err
+	}
+	if stat, err := os.Stat(sdkCachePath); err != nil || !stat.IsDir() {
+		return "", fmt.Errorf("no SDK found in '%s'.\nYou must setup the esp32 image using 'jag setup'", sdkCachePath)
+	}
+	return sdkCachePath, nil
+}
+
 func GetSDKCachePath() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -106,9 +118,9 @@ func GetESP32ImageCachePath() (string, error) {
 }
 
 func GetESP32ImagePath() (string, error) {
-	imagePath, ok := os.LookupEnv(Esp32ImageEnv)
+	toit_repo_path, ok := os.LookupEnv(ToitRepoPathEnv)
 	if ok {
-		return imagePath, nil
+		return filepath.Join(toit_repo_path, "build", "esp32"), nil
 	}
 
 	imagePath, err := GetESP32ImageCachePath()
@@ -122,6 +134,18 @@ func GetESP32ImagePath() (string, error) {
 }
 
 func GetJaguarSnapshotPath() (string, error) {
+	_, ok := os.LookupEnv(ToitRepoPathEnv)
+	if ok {
+		// We assume that the jaguar executable is inside the build directory
+		// of the Jag repository.
+		execPath, err := os.Executable()
+		if err != nil {
+			return "", err
+		}
+		dir := path.Dir(execPath)
+		return filepath.Join(dir, "image", "jaguar.snapshot"), nil
+	}
+
 	imagePath, err := GetESP32ImagePath()
 	if err != nil {
 		return "", err
@@ -143,9 +167,9 @@ func GetEsptoolCachePath() (string, error) {
 }
 
 func GetEsptoolPath() (string, error) {
-	esptoolPath, ok := os.LookupEnv(EsptoolPathEnv)
+	toit_repo_path, ok := os.LookupEnv(ToitRepoPathEnv)
 	if ok {
-		return esptoolPath, nil
+		return filepath.Join(toit_repo_path, "third_party", "esp-idf", "components", "esptool_py", "esptool", "esptool.py"), nil
 	}
 
 	cachePath, err := GetEsptoolCachePath()

--- a/cmd/jag/directory/directory.go
+++ b/cmd/jag/directory/directory.go
@@ -87,9 +87,9 @@ func GetSnapshotsCachePath() (string, error) {
 }
 
 func GetSDKPath() (string, error) {
-	toit_repo_path, ok := os.LookupEnv(ToitRepoPathEnv)
+	toitRepoPath, ok := os.LookupEnv(ToitRepoPathEnv)
 	if ok {
-		return filepath.Join(toit_repo_path, "build", "host", "sdk"), nil
+		return filepath.Join(toitRepoPath, "build", "host", "sdk"), nil
 	}
 	sdkCachePath, err := GetSDKCachePath()
 	if err != nil {
@@ -118,9 +118,9 @@ func GetESP32ImageCachePath() (string, error) {
 }
 
 func GetESP32ImagePath() (string, error) {
-	toit_repo_path, ok := os.LookupEnv(ToitRepoPathEnv)
+	toitRepoPath, ok := os.LookupEnv(ToitRepoPathEnv)
 	if ok {
-		return filepath.Join(toit_repo_path, "build", "esp32"), nil
+		return filepath.Join(toitRepoPath, "build", "esp32"), nil
 	}
 
 	imagePath, err := GetESP32ImageCachePath()
@@ -136,8 +136,8 @@ func GetESP32ImagePath() (string, error) {
 func GetJaguarSnapshotPath() (string, error) {
 	_, ok := os.LookupEnv(ToitRepoPathEnv)
 	if ok {
-		// We assume that the jaguar executable is inside the build directory
-		// of the Jag repository.
+		// We assume that the jag executable is inside the build directory of
+		// the Jaguar repository.
 		execPath, err := os.Executable()
 		if err != nil {
 			return "", err
@@ -167,9 +167,9 @@ func GetEsptoolCachePath() (string, error) {
 }
 
 func GetEsptoolPath() (string, error) {
-	toit_repo_path, ok := os.LookupEnv(ToitRepoPathEnv)
+	toitRepoPath, ok := os.LookupEnv(ToitRepoPathEnv)
 	if ok {
-		return filepath.Join(toit_repo_path, "third_party", "esp-idf", "components", "esptool_py", "esptool", "esptool.py"), nil
+		return filepath.Join(toitRepoPath, "third_party", "esp-idf", "components", "esptool_py", "esptool", "esptool.py"), nil
 	}
 
 	cachePath, err := GetEsptoolCachePath()


### PR DESCRIPTION
If the `JAG_TOIT_REPO_PATH` is set, we
- Find and build the SDK in it.
- Use the IDF from that Toit repository.
- Assume that we are in development mode, and thus find
  the jaguar.snapshot relative to the jag executable.

Also, the Makefile was modified, to only use `?=` for variables that we
want to influence with environment variables.