### PR TITLE
Add new command, compile, that makes a snapshot

### DIFF
--- a/cmd/jag/commands/compile.go
+++ b/cmd/jag/commands/compile.go
@@ -20,6 +20,7 @@ func CompileCmd() *cobra.Command {
 			"can be run on a Jaguar device as a new program.  The snapshot also\n" +
 			"contains debug information that can be used by host-side tools.",
 		Args:         cobra.ExactArgs(1),
+		Hidden:       true,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			entrypoint := args[0]

--- a/cmd/jag/commands/compile.go
+++ b/cmd/jag/commands/compile.go
@@ -1,0 +1,84 @@
+// Copyright (C) 2021 Toitware ApS. All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func CompileCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "compile <file>",
+		Short: "Compile Toit code to a snapshot",
+		Long: "Compile Toit code to a snapshot file.  The snapshot is an executable\n" +
+			"can be run on a Jaguar device as a new program.  The snapshot also\n" +
+			"contains debug information that can be used by host-side tools.",
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			entrypoint := args[0]
+			if stat, err := os.Stat(entrypoint); err != nil {
+				if os.IsNotExist(err) {
+					return fmt.Errorf("no such file or directory: '%s'", entrypoint)
+				}
+				return fmt.Errorf("can't stat file '%s', reason: %w", entrypoint, err)
+			} else if stat.IsDir() {
+				return fmt.Errorf("can't run directory: '%s'", entrypoint)
+			}
+
+			ctx := cmd.Context()
+
+			sdk, err := GetSDK(ctx)
+			if err != nil {
+				return err
+			}
+
+			outputfile := ""
+
+			if !cmd.Flags().Changed("output") {
+				dot := strings.LastIndex(entrypoint, ".")
+				slash := strings.LastIndex(entrypoint, "/")
+				backslash := strings.LastIndex(entrypoint, "\\")
+				fail := false
+				if dot == -1 {
+					fail = true
+				} else if slash != -1 && slash > dot {
+					fail = true
+				} else if backslash != -1 && backslash > dot {
+					fail = true
+				}
+				if fail {
+					return fmt.Errorf("can't construct snapshot name from directory: '%s'", entrypoint)
+				}
+				outputfile = entrypoint[0:dot] + ".snapshot"
+			} else {
+				outputfile, err = cmd.Flags().GetString("output")
+				if err != nil {
+					return err
+				}
+			}
+
+			fmt.Printf("Compiling '%s' to '%s'\n", entrypoint, outputfile)
+
+			err = sdk.Compile(ctx, outputfile, entrypoint)
+			if err != nil {
+				// We assume the error has been printed.
+				// Mark the command as silent to avoid printing the error twice.
+				cmd.SilenceErrors = true
+				return err
+			}
+
+			fmt.Printf("Success: Wrote compiled bytecodes to '%s'\n", outputfile)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringP("output", "o", "", "Specify output (snapshot) file")
+	return cmd
+}

--- a/cmd/jag/commands/jag.go
+++ b/cmd/jag/commands/jag.go
@@ -64,6 +64,7 @@ func JagCmd(info Info) *cobra.Command {
 		ScanCmd(),
 		PingCmd(),
 		RunCmd(),
+		CompileCmd(),
 		SimulateCmd(),
 		DecodeCmd(),
 		SetupCmd(info),

--- a/cmd/jag/commands/util.go
+++ b/cmd/jag/commands/util.go
@@ -157,20 +157,17 @@ func (s *SDK) ToitLsp(ctx context.Context, args []string) *exec.Cmd {
 	return exec.CommandContext(ctx, s.ToitLspPath(), args...)
 }
 
-func (s *SDK) Build(ctx context.Context, device *Device, entrypoint string) ([]byte, error) {
-	snapshotsCache, err := directory.GetSnapshotsCachePath()
-	if err != nil {
-		return nil, err
-	}
-	snapshot := filepath.Join(snapshotsCache, device.ID+".snapshot")
-
+func (s *SDK) Compile(ctx context.Context, snapshot string, entrypoint string) error {
 	buildSnap := s.ToitCompile(ctx, "-w", snapshot, entrypoint)
 	buildSnap.Stderr = os.Stderr
 	buildSnap.Stdout = os.Stdout
 	if err := buildSnap.Run(); err != nil {
-		return nil, err
+		return err
 	}
+	return nil
+}
 
+func (s *SDK) Build(ctx context.Context, device *Device, snapshot string) ([]byte, error) {
 	image, err := os.CreateTemp("", "*.image")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Next step will be changing "jag run" so it can take a precompiled snapshot file.
Then adding other utilities that can use the snapshot file.