### PR TITLE
Use uuid in snapshot as cache filename.

### DIFF
--- a/cmd/jag/commands/flash.go
+++ b/cmd/jag/commands/flash.go
@@ -167,7 +167,7 @@ func FlashCmd() *cobra.Command {
 			}
 			defer os.Remove(jaguarImageFile.Name())
 
-			snapshotToImageCmd := sdk.ToitRun(ctx, sdk.SnapshotToImagePath(), "--unique_id", id.String(), "-m32", "--binary", "--offset=0x0", jaguarSnapshotPath, jaguarImageFile.Name())
+			snapshotToImageCmd := sdk.ToitRun(ctx, sdk.SnapshotToImagePath(), "--unique_id", id.String(), "-m32", "--binary", "--offset=0x0", "--output", jaguarImageFile.Name(), jaguarSnapshotPath)
 			snapshotToImageCmd.Stderr = os.Stderr
 			snapshotToImageCmd.Stdout = os.Stdout
 			if err := snapshotToImageCmd.Run(); err != nil {

--- a/cmd/jag/commands/util.go
+++ b/cmd/jag/commands/util.go
@@ -180,7 +180,7 @@ func (s *SDK) Build(ctx context.Context, device *Device, snapshot string) ([]byt
 		bits = "-m64"
 	}
 
-	buildImage := s.ToitRun(ctx, s.SnapshotToImagePath(), "--binary", bits, snapshot, image.Name())
+	buildImage := s.ToitRun(ctx, s.SnapshotToImagePath(), "--binary", bits, "--output", image.Name(), snapshot)
 	buildImage.Stderr = os.Stderr
 	buildImage.Stdout = os.Stdout
 	if err := buildImage.Run(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require github.com/spf13/cobra v1.2.1
 
 require (
+	github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb // indirect
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/bradfitz/gomemcache v0.0.0-20220106215444-fb4bf637b56d
 	github.com/cheggaaa/pb/v3 v3.0.8

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
+github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb h1:m935MPodAbYS46DG4pJSv7WO+VECIWUQ7OJYSoTrMh4=
+github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb/go.mod h1:PkYb9DJNAwrSvRx5DYA+gUcOIgTGVMNkfSCbZM8cWpI=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bradfitz/gomemcache v0.0.0-20220106215444-fb4bf637b56d h1:pVrfxiGfwelyab6n21ZBkbkmbevaf+WvMIiR7sr97hw=


### PR DESCRIPTION
Also fixes to use the new command line syntax for snapshot_to_image.

Also allows `jag run` to run snapshot files, eg from the cache.

Doesn't yet fix `jag decode` to decode errors.

I'm seeing an issue where the jaguar program gets deleted from
devices.  May be unrelated.