### PR TITLE
Auto-decode stack traces for jag simulate

### DIFF
--- a/cmd/jag/commands/decode.go
+++ b/cmd/jag/commands/decode.go
@@ -190,7 +190,7 @@ func (d *Decoder) decode() {
 	postponed := []string{}
 
 	for d.scanner.Scan() {
-		// Get next line from serial port.
+		// Get next line from device (or simulator) console.
 		line := d.scanner.Text()
 		versionPrefix := "[toit] INFO: starting <v"
 		if strings.HasPrefix(line, versionPrefix) && strings.HasSuffix(line, ">") {

--- a/cmd/jag/commands/monitor.go
+++ b/cmd/jag/commands/monitor.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -23,12 +22,6 @@ func MonitorCmd() *cobra.Command {
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			Version := ""
-			POSTPONED_LINES := map[string]bool{
-				"----": true,
-				"Received a Toit stack trace. Executing the command below will": true,
-				"make it human readable:": true,
-			}
 
 			port, err := cmd.Flags().GetString("port")
 			if err != nil {
@@ -63,45 +56,9 @@ func MonitorCmd() *cobra.Command {
 
 			scanner := bufio.NewScanner(dev)
 
-			postponed := []string{}
+			decoder := Decoder{scanner, cmd}
 
-			for scanner.Scan() {
-				// Get next line from serial port.
-				line := scanner.Text()
-				versionPrefix := "[toit] INFO: starting <v"
-				if strings.HasPrefix(line, versionPrefix) && strings.HasSuffix(line, ">") {
-					Version = line[len(versionPrefix) : len(line)-1]
-				}
-				if _, contains := POSTPONED_LINES[line]; contains {
-					postponed = append(postponed, line)
-				} else {
-					separator := strings.Repeat("*", 78)
-					if strings.HasPrefix(line, "jag decode ") || strings.HasPrefix(line, "Backtrace:") {
-						fmt.Printf("\n" + separator + "\n")
-						if Version != "" {
-							fmt.Printf("Decoded by `jag monitor` <%s>\n", Version)
-							fmt.Printf(separator + "\n")
-						}
-						if err := serialDecode(cmd, line); err != nil {
-							if len(postponed) != 0 {
-								fmt.Println(strings.Join(postponed, "\n"))
-								postponed = []string{}
-							}
-							fmt.Println(line)
-							fmt.Println("jag monitor: Failed to decode line.")
-						} else {
-							postponed = []string{}
-						}
-						fmt.Printf(separator + "\n\n")
-					} else {
-						if len(postponed) != 0 {
-							fmt.Println(strings.Join(postponed, "\n"))
-							postponed = []string{}
-						}
-						fmt.Println(line)
-					}
-				}
-			}
+			decoder.decode()
 
 			return scanner.Err()
 		},

--- a/cmd/jag/commands/simulate.go
+++ b/cmd/jag/commands/simulate.go
@@ -51,12 +51,12 @@ func SimulateCmd() *cobra.Command {
 				return err
 			}
 
-			outR, outW := io.Pipe()
+			outReader, outWriter := io.Pipe()
 
 			// Goroutine that gets data from the pipe and converts it into
 			// lines.
 			go func() {
-				scanner := bufio.NewScanner(outR)
+				scanner := bufio.NewScanner(outReader)
 
 				decoder := Decoder{scanner, cmd}
 
@@ -65,7 +65,7 @@ func SimulateCmd() *cobra.Command {
 
 			simCmd := sdk.ToitRun(ctx, snapshot, strconv.Itoa(int(port)), id.String(), name)
 			simCmd.Stderr = os.Stderr
-			simCmd.Stdout = outW
+			simCmd.Stdout = outWriter
 			return simCmd.Run()
 		},
 	}

--- a/cmd/jag/commands/simulate.go
+++ b/cmd/jag/commands/simulate.go
@@ -5,6 +5,8 @@
 package commands
 
 import (
+	"bufio"
+	"io"
 	"os"
 	"strconv"
 
@@ -49,9 +51,21 @@ func SimulateCmd() *cobra.Command {
 				return err
 			}
 
+			outR, outW := io.Pipe()
+
+			// Goroutine that gets data from the pipe and converts it into
+			// lines.
+			go func() {
+				scanner := bufio.NewScanner(outR)
+
+				decoder := Decoder{scanner, cmd}
+
+				decoder.decode()
+			}()
+
 			simCmd := sdk.ToitRun(ctx, snapshot, strconv.Itoa(int(port)), id.String(), name)
 			simCmd.Stderr = os.Stderr
-			simCmd.Stdout = os.Stdout
+			simCmd.Stdout = outW
 			return simCmd.Run()
 		},
 	}


### PR DESCRIPTION
Currently the stack trace decoding on the device is broken by things getting
mixed up on the serial line, but that is independent of this change.
