### PR TITLE
Small user-friendly text changes.

### DIFF
--- a/cmd/jag/commands/config.go
+++ b/cmd/jag/commands/config.go
@@ -131,7 +131,7 @@ func ConfigWifiCmd() *cobra.Command {
 			return directory.WriteConfig(cfg)
 		},
 	}
-	setCmd.Flags().String("wifi-ssid", os.Getenv(directory.WifiSSIDEnv), "default WiFi SSID")
+	setCmd.Flags().String("wifi-ssid", os.Getenv(directory.WifiSSIDEnv), "default WiFi network name")
 	setCmd.Flags().String("wifi-password", os.Getenv(directory.WifiPasswordEnv), "default WiFi password")
 	setCmd.MarkFlagRequired("wifi-ssid")
 	setCmd.MarkFlagRequired("wifi-password")

--- a/cmd/jag/commands/firmware.go
+++ b/cmd/jag/commands/firmware.go
@@ -133,7 +133,7 @@ func FirmwareUpdateCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("wifi-ssid", "", "default WiFi SSID")
+	cmd.Flags().String("wifi-ssid", "", "default WiFi network name")
 	cmd.Flags().String("wifi-password", "", "default WiFi password")
 	cmd.Flags().StringP("device", "d", "", "use device with a given name, id, or address")
 	return cmd

--- a/cmd/jag/commands/flash.go
+++ b/cmd/jag/commands/flash.go
@@ -211,7 +211,7 @@ func FlashCmd() *cobra.Command {
 
 	cmd.Flags().StringP("port", "p", ConfiguredPort(), "serial port to flash via")
 	cmd.Flags().Uint("baud", 921600, "baud rate used for the serial flashing")
-	cmd.Flags().String("wifi-ssid", "", "default WiFi SSID")
+	cmd.Flags().String("wifi-ssid", "", "default WiFi network name")
 	cmd.Flags().String("wifi-password", "", "default WiFi password")
 	cmd.Flags().String("name", "", "name for the device, if not set a name will be auto generated")
 	return cmd

--- a/src/jaguar.toit
+++ b/src/jaguar.toit
@@ -340,7 +340,7 @@ handle_browser_request name/string request/http.Request writer/http.ResponseWrit
               </section>
               <p class="hr mt-20"></p>
               <p class="mt-40">Run code on this device using</p>
-              <b><a href="https://github.com/toitlang/jaguar">&gt; jag run</a></b>
+              <b><a href="https://github.com/toitlang/jaguar">&gt; jag run -d $name hello.toit</a></b>
               <p class="mt-20">Monitor the serial port console using</p>
               <p class="mb-20"><b><a href="https://github.com/toitlang/jaguar">&gt; jag monitor</a></b></p>
             </div>


### PR DESCRIPTION
Give a more specific jag run command for the
mini-web server, including the -d option.

Use "network name" in the help for the SSID options. If the user remembers what an SSID is they don't need the help, and if they don't then this is more helpful.