### PR TITLE
Don't complain when the nil snapshot is not present.

### DIFF
--- a/cmd/jag/commands/decode.go
+++ b/cmd/jag/commands/decode.go
@@ -134,9 +134,11 @@ func jagDecode(cmd *cobra.Command, base64Message string) error {
 	}
 	snapshot := filepath.Join(snapshotsCache, programId.String()+".snapshot")
 
-	if _, err := os.Stat(snapshot); errors.Is(err, os.ErrNotExist) {
-		fmt.Fprintf(os.Stderr, "No such file: %s\n", snapshot)
-		return fmt.Errorf("cannot find snapshot for program: %s", programId.String())
+	if programId != uuid.Nil {
+		if _, err := os.Stat(snapshot); errors.Is(err, os.ErrNotExist) {
+			fmt.Fprintf(os.Stderr, "No such file: %s\n", snapshot)
+			return fmt.Errorf("cannot find snapshot for program: %s", programId.String())
+		}
 	}
 
 	decodeCommand := sdk.SystemMessage(ctx, snapshot, "-b", base64Message)


### PR DESCRIPTION
Some jag decode lines don't refer to a particular snapshot because they apply to the whole system.  In that case we don't require the snapshots directory to contain the snapshot file with the nil UUID.