### PR TITLE
Upgrade SDK and prepare to release v1.8.2

### DIFF
--- a/cmd/jag/main.go
+++ b/cmd/jag/main.go
@@ -13,8 +13,8 @@ import (
 )
 
 var (
-	version    = "v1.8.1"
-	sdkVersion = "v2.0.0-alpha.47"
+	version    = "v1.8.2"
+	sdkVersion = "v2.0.0-alpha.48"
 )
 
 var buildDate = "unknown"


### PR DESCRIPTION
I suggest we send this out as a pre-release first to get some basic testing of the CGO_ENABLED changes first.