### PR TITLE
Use newer "ReadPassword" and fall back to visible readline.

### DIFF
--- a/cmd/jag/commands/util.go
+++ b/cmd/jag/commands/util.go
@@ -512,9 +512,9 @@ func getWifiCredentials(cmd *cobra.Command) (string, string, error) {
 	} else {
 		fmt.Printf("Enter WiFi password for '%s': ", wifiSSID)
 		pw := ""
-		pw_bytes, err := ReadPassword()
+		pwBytes, err := ReadPassword()
 		if err == nil {
-			pw = string(pw_bytes)
+			pw = string(pwBytes)
 			fmt.Printf("\n")
 		} else {
 			// Fall back to reading the password without hiding it.

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	go.bug.st/serial v1.5.0
 	golang.org/x/crypto v0.5.0
 	golang.org/x/net v0.5.0
+	golang.org/x/term v0.4.0 // indirect
 	golang.org/x/tools v0.5.0 // indirect
 	google.golang.org/genproto v0.0.0-20230109162033-3c3c17ce83e6 // indirect
 	gopkg.in/yaml.v2 v2.4.0


### PR DESCRIPTION
On Windows, in git-bash (and similar shells) the 'ReadPassword' function has difficulties.

See https://github.com/golang/go/issues/11914#issuecomment-613715787.

Fixes #336.