### PR TITLE
Set server timeout to 3s, roll to new HTTP pkg.

### DIFF
--- a/package.lock
+++ b/package.lock
@@ -1,5 +1,8 @@
+sdk: ^2.0.0-alpha.79
 prefixes:
   http: pkg-http
 packages:
   pkg-http:
-    path: ../pkg-http
+    url: github.com/toitlang/pkg-http
+    version: 2.2.0
+    hash: c2acc29817b34085aad4b798c6dafdeef77c23ae

--- a/package.lock
+++ b/package.lock
@@ -2,6 +2,4 @@ prefixes:
   http: pkg-http
 packages:
   pkg-http:
-    url: github.com/toitlang/pkg-http
-    version: 2.1.0
-    hash: 54cb9c5e06d53da3d5608ea7454b9113de079c15
+    path: ../pkg-http

--- a/package.yaml
+++ b/package.yaml
@@ -1,3 +1,4 @@
 dependencies:
   http:
-    path: ../pkg-http
+    url: github.com/toitlang/pkg-http
+    version: ^2.2.0

--- a/package.yaml
+++ b/package.yaml
@@ -1,4 +1,3 @@
 dependencies:
   http:
-    url: github.com/toitlang/pkg-http
-    version: ^2.1.0
+    path: ../pkg-http

--- a/src/jaguar.toit
+++ b/src/jaguar.toit
@@ -396,7 +396,7 @@ handle_browser_request name/string request/http.Request writer/http.ResponseWrit
 serve_incoming_requests socket/tcp.ServerSocket device/Device address/string -> none:
   self := Task.current
 
-  server := http.Server --logger=logger
+  server := http.Server --logger=logger --read_timeout=(Duration --s=3)
 
   server.listen socket:: | request/http.Request writer/http.ResponseWriter |
     headers ::= request.headers


### PR DESCRIPTION
When we load the mini web page in a browser, the browser will tend to leave the connection open for a long time. With this change we quickly time out the connection so that the jag command line is not blocked (we run with only one connection at a time on the devices).

This also rolls to the new HTTP pkg version 2.2.0.