### PR TITLE
Support 'JAG_TOIT_REPO_PATH' on Windows

### DIFF
--- a/cmd/jag/directory/directory.go
+++ b/cmd/jag/directory/directory.go
@@ -7,7 +7,6 @@ package directory
 import (
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 
@@ -127,7 +126,7 @@ func GetAssetsPath() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		dir := path.Dir(execPath)
+		dir := filepath.Dir(execPath)
 		return filepath.Join(dir, "assets"), nil
 	}
 


### PR DESCRIPTION
`path` only works for slash paths.
