### PR TITLE
Fix 'firmware container list' invocation

### DIFF
--- a/cmd/jag/commands/firmware.go
+++ b/cmd/jag/commands/firmware.go
@@ -351,7 +351,7 @@ func copySnapshotsIntoCache(ctx context.Context, sdk *SDK, envelope *os.File) er
 	}
 	defer os.Remove(listFile.Name())
 
-	if err := runFirmwareTool(ctx, sdk, envelope.Name(), "container", "list", "-o", listFile.Name()); err != nil {
+	if err := runFirmwareTool(ctx, sdk, envelope.Name(), "container", "list", "--output-format", "json", "-o", listFile.Name()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
I still find it a bit hard to remember that it's:

`tools/firmware extract --format binary -o firm.bin`

but

`tools/firmware container list --output-format json -o containers.json`