### PR TITLE
Version the envelopes path.

### DIFF
--- a/cmd/jag/directory/directory.go
+++ b/cmd/jag/directory/directory.go
@@ -113,6 +113,14 @@ func GetSDKCachePath() (string, error) {
 	return filepath.Join(home, ".cache", "jaguar", "sdk"), nil
 }
 
+func GetEnvelopesCachePath(version string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".cache", "jaguar", version, "envelopes"), nil
+}
+
 func GetAssetsCachePath() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {


### PR DESCRIPTION
Since we don't download the envelopes at `setup`, we have to make sure we don't use the envelopes from earlier downloads.

At the moment we don't delete old envelopes, but that could be added.