### PR TITLE
Checkout before go-setup.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -277,12 +277,12 @@ jobs:
   build_assets:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
           go-version: 1.19
-
-      - uses: actions/checkout@v3
 
       - name: Download SDK
         run: |


### PR DESCRIPTION
The go-setup uses the go.sum file as a cache key. That means that we need to checkout our sources before Go is set up.