### PR TITLE
Download envelopes to a temporary file first.

### DIFF
--- a/cmd/jag/commands/envelope.go
+++ b/cmd/jag/commands/envelope.go
@@ -138,7 +138,7 @@ func downloadPublishedFirmware(ctx context.Context, version string, model string
 		return err
 	}
 
-	// Rename the tmp file to the final file.
+	// Rename the temporary file to the final file.
 	err = os.Rename(tmpEnvelopePath, envelopePath)
 	if err != nil {
 		return err

--- a/cmd/jag/commands/envelope.go
+++ b/cmd/jag/commands/envelope.go
@@ -131,7 +131,15 @@ func downloadPublishedFirmware(ctx context.Context, version string, model string
 
 	envelopeFileName := GetFirmwareEnvelopeFileName(model)
 	envelopePath := filepath.Join(envelopesDir, envelopeFileName)
-	err = downloadGzipped(ctx, firmwareURL, envelopePath)
+	// First download to a temporary file, in case the download doesn't complete.
+	tmpEnvelopePath := envelopePath + ".tmp"
+	err = downloadGzipped(ctx, firmwareURL, tmpEnvelopePath)
+	if err != nil {
+		return err
+	}
+
+	// Rename the tmp file to the final file.
+	err = os.Rename(tmpEnvelopePath, envelopePath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We had cases where the download was aborted and we then tried to use incomplete files.