### PR TITLE
Store snapshots in ~/.local/state/toit/snapshots.

### DIFF
--- a/cmd/jag/commands/decode.go
+++ b/cmd/jag/commands/decode.go
@@ -149,9 +149,15 @@ func jagDecode(ctx context.Context, base64Message string, forcePretty bool, forc
 	}
 	snapshot := ""
 	for _, path := range snapshotsPaths {
-		snapshot = filepath.Join(path, programId.String()+".snapshot")
-		_, err := os.Stat(snapshot)
+		candidate := filepath.Join(path, programId.String()+".snapshot")
+		if snapshot == "" {
+			// Remember the first candidate so we use it in the error message if
+			// we don't find any snapshot.
+			snapshot = candidate
+		}
+		_, err := os.Stat(candidate)
 		if err == nil || !errors.Is(err, os.ErrNotExist) {
+			snapshot = candidate
 			break
 		}
 	}

--- a/cmd/jag/commands/decode.go
+++ b/cmd/jag/commands/decode.go
@@ -143,11 +143,18 @@ func jagDecode(ctx context.Context, base64Message string, forcePretty bool, forc
 		return fmt.Errorf("failed to parse program id: %v", err)
 	}
 
-	snapshotsCache, err := directory.GetSnapshotsCachePath()
+	snapshotsPaths, err := directory.GetSnapshotsPaths()
 	if err != nil {
 		return err
 	}
-	snapshot := filepath.Join(snapshotsCache, programId.String()+".snapshot")
+	snapshot := ""
+	for _, path := range snapshotsPaths {
+		snapshot = filepath.Join(path, programId.String()+".snapshot")
+		_, err := os.Stat(snapshot)
+		if err == nil || !errors.Is(err, os.ErrNotExist) {
+			break
+		}
+	}
 
 	pretty := "--no-force-pretty"
 	if forcePretty {

--- a/cmd/jag/commands/firmware.go
+++ b/cmd/jag/commands/firmware.go
@@ -416,7 +416,7 @@ func copySnapshotIntoCache(path string) error {
 		return err
 	}
 
-	cacheDirectory, err := directory.GetSnapshotsCachePath()
+	stateDirectory, err := directory.GetSnapshotsStatePath()
 	if err != nil {
 		return err
 	}
@@ -427,7 +427,7 @@ func copySnapshotIntoCache(path string) error {
 	}
 	defer source.Close()
 
-	destination, err := os.Create(filepath.Join(cacheDirectory, uuid.String()+".snapshot"))
+	destination, err := os.Create(filepath.Join(stateDirectory, uuid.String()+".snapshot"))
 	if err != nil {
 		return err
 	}

--- a/cmd/jag/commands/run.go
+++ b/cmd/jag/commands/run.go
@@ -252,7 +252,7 @@ func sendCodeFromFile(
 	optimizationLevel int) error {
 
 	ctx := cmd.Context()
-	snapshotsCache, err := directory.GetSnapshotsCachePath()
+	snapshotsStateDir, err := directory.GetSnapshotsStatePath()
 	if err != nil {
 		return err
 	}
@@ -289,7 +289,7 @@ func sendCodeFromFile(
 		return err
 	}
 
-	cacheDestination := filepath.Join(snapshotsCache, programId.String()+".snapshot")
+	cacheDestination := filepath.Join(snapshotsStateDir, programId.String()+".snapshot")
 
 	// Copy the snapshot into the cache dir so it is available for
 	// decoding stack traces etc.  We want to add it to the cache in
@@ -298,9 +298,9 @@ func sendCodeFromFile(
 	// first copying to a temp file in the cache dir, then renaming
 	// in that directory.
 	if cacheDestination != snapshot {
-		tempFileInCacheDirectory, err := os.CreateTemp(snapshotsCache, "jag_run_*.snapshot")
+		tempFileInCacheDirectory, err := os.CreateTemp(snapshotsStateDir, "jag_run_*.snapshot")
 		if err != nil {
-			fmt.Printf("Failed to write temporary file in '%s'\n", snapshotsCache)
+			fmt.Printf("Failed to write temporary file in '%s'\n", snapshotsStateDir)
 			return err
 		}
 		defer tempFileInCacheDirectory.Close()


### PR DESCRIPTION
XDG_STATE_HOME seems to be the directory that fits best.

Quoting the [freedesktop.org specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html):
The $XDG_STATE_HOME contains state data that should persist between (application) restarts, but that is not important or portable enough to the user that it should be stored in $XDG_DATA_HOME. It may contain:

- actions history (logs, history, recently used files, …)

- current state of the application that can be reused on a restart (view, layout, open files, undo history, …)