### PR TITLE
Don't run non-existing PostRun.

### DIFF
--- a/cmd/jag/main.go
+++ b/cmd/jag/main.go
@@ -32,10 +32,6 @@ func main() {
 	ctx := commands.SetInfo(context.Background(), info)
 	cmd := commands.JagCmd(info, isReleaseBuild)
 	if err := cmd.ExecuteContext(ctx); err != nil {
-		// The 'jag' command needs to have its "post run" function called
-		// even when we exit with an error. The cobra framework doesn't
-		// automatically call this, so we do it manually.
-		cmd.PersistentPostRun(cmd, cmd.Flags().Args())
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
By removing the analytics code (#534), the post-run function isn't set anymore, and calling it would yield a nil pointer dereference.