### PR TITLE
Revert "Use 'toit' executable instead of the tools. (#538)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,14 +55,14 @@ $(BUILD_DIR)/$(JAG_BINARY): $(JAG_GO_SOURCES)
 assets: $(BUILD_DIR)/assets/jaguar.snapshot
 
 $(BUILD_DIR)/assets/jaguar.snapshot: install-dependencies
-$(BUILD_DIR)/assets/jaguar.snapshot: $(SDK_PATH)/bin/toit$(EXE_SUFFIX)
+$(BUILD_DIR)/assets/jaguar.snapshot: $(SDK_PATH)/bin/toit.compile$(EXE_SUFFIX)
 $(BUILD_DIR)/assets/jaguar.snapshot: $(JAG_TOIT_SOURCES)
 	mkdir -p $(BUILD_DIR)/assets
-	$(SDK_PATH)/bin/toit$(EXE_SUFFIX) compile -O2 --snapshot -o $@ $(JAG_ENTRY_POINT)
+	$(SDK_PATH)/bin/toit.compile$(EXE_SUFFIX) -O2 -w $@ $(JAG_ENTRY_POINT)
 
 .PHONY: install-dependencies
-install-dependencies: $(SDK_PATH)/bin/toit$(EXE_SUFFIX)
-	$(SDK_PATH)/bin/toit$(EXE_SUFFIX) pkg --project-root=$(CURDIR) install
+install-dependencies: $(SDK_PATH)/bin/toit.pkg$(EXE_SUFFIX)
+	$(SDK_PATH)/bin/toit.pkg$(EXE_SUFFIX) --project-root=$(CURDIR) install
 
 ############################################
 # Rules to build with JAG_TOIT_REPO_PATH set
@@ -71,7 +71,8 @@ install-dependencies: $(SDK_PATH)/bin/toit$(EXE_SUFFIX)
 ifdef JAG_TOIT_REPO_PATH
 all: $(JAG_TOIT_REPO_PATH)/build/esp32/firmware.envelope
 
-JAG_TOIT_DEPENDENCIES  = $(SDK_PATH)/bin/toit$(EXE_SUFFIX)
+JAG_TOIT_DEPENDENCIES  = $(SDK_PATH)/bin/toit.compile$(EXE_SUFFIX)
+JAG_TOIT_DEPENDENCIES += $(SDK_PATH)/bin/toit.pkg$(EXE_SUFFIX)
 JAG_TOIT_DEPENDENCIES += $(JAG_TOIT_REPO_PATH)/build/esp32/firmware.envelope
 
 # We use a marker in the build directory to avoid

--- a/cmd/jag/commands/decode.go
+++ b/cmd/jag/commands/decode.go
@@ -171,13 +171,13 @@ func jagDecode(ctx context.Context, base64Message string, forcePretty bool, forc
 		plain = "--force-plain"
 	}
 
-	var decodeCommand *exec.Cmd = sdk.SystemMessage(ctx, base64Message, pretty, plain)
+	var decodeCommand *exec.Cmd = sdk.SystemMessage(ctx, "--message", base64Message, pretty, plain)
 	isMissingSnapshot := false
 	if programId != uuid.Nil {
 		if _, err := os.Stat(snapshot); errors.Is(err, os.ErrNotExist) {
 			isMissingSnapshot = true
 		} else {
-			decodeCommand = sdk.SystemMessage(ctx, "--snapshot", snapshot, base64Message, pretty, plain)
+			decodeCommand = sdk.SystemMessage(ctx, "--snapshot", snapshot, "--message", base64Message, pretty, plain)
 		}
 	} else {
 

--- a/cmd/jag/commands/toit.go
+++ b/cmd/jag/commands/toit.go
@@ -37,7 +37,7 @@ func ToitLspCmd() *cobra.Command {
 			}
 
 			cmd.SilenceErrors = true
-			toitLsp := sdk.ToitLsp(ctx, args)
+			toitLsp := sdk.ToitLsp(ctx, append([]string{"--toitc", sdk.ToitCompilePath()}, args...))
 			toitLsp.Stdin = os.Stdin
 			toitLsp.Stdout = os.Stdout
 			toitLsp.Stderr = os.Stderr

--- a/cmd/jag/commands/util.go
+++ b/cmd/jag/commands/util.go
@@ -86,8 +86,16 @@ func GetProgramAssetsPath(flags *pflag.FlagSet, flagName string) (string, error)
 	return assetsPath, nil
 }
 
-func (s *SDK) ToitPath() string {
-	return filepath.Join(s.Path, "bin", directory.Executable("toit"))
+func (s *SDK) ToitCompilePath() string {
+	return filepath.Join(s.Path, "bin", directory.Executable("toit.compile"))
+}
+
+func (s *SDK) ToitRunPath() string {
+	return filepath.Join(s.Path, "bin", directory.Executable("toit.run"))
+}
+
+func (s *SDK) ToitLspPath() string {
+	return filepath.Join(s.Path, "bin", directory.Executable("toit.lsp"))
 }
 
 func (s *SDK) VersionPath() string {
@@ -96,6 +104,25 @@ func (s *SDK) VersionPath() string {
 
 func (s *SDK) DownloaderInfoPath() string {
 	return filepath.Join(s.Path, "JAGUAR")
+}
+
+func (s *SDK) SystemMessagePath() string {
+	return filepath.Join(s.Path, "tools", directory.Executable("system_message"))
+}
+
+func (s *SDK) SnapshotToImagePath() string {
+	return filepath.Join(s.Path, "tools", directory.Executable("snapshot_to_image"))
+}
+
+func (s *SDK) AssetsToolPath() string {
+	return filepath.Join(s.Path, "tools", directory.Executable("assets"))
+}
+
+func (s *SDK) FirmwareToolPath() string {
+	return filepath.Join(s.Path, "tools", directory.Executable("firmware"))
+}
+func (s *SDK) StacktracePath() string {
+	return filepath.Join(s.Path, "tools", directory.Executable("stacktrace"))
 }
 
 func (s *SDK) validate(info Info, skipSdkVersionCheck bool) error {
@@ -123,8 +150,15 @@ func (s *SDK) validate(info Info, skipSdkVersionCheck bool) error {
 	}
 
 	paths := []string{
-		s.ToitPath(),
+		s.ToitCompilePath(),
+		s.ToitRunPath(),
+		s.ToitLspPath(),
 		s.VersionPath(),
+		s.AssetsToolPath(),
+		s.FirmwareToolPath(),
+		s.SystemMessagePath(),
+		s.SnapshotToImagePath(),
+		s.StacktracePath(),
 	}
 	for _, p := range paths {
 		if err := checkFilepath(p, "invalid Toit SDK"); err != nil {
@@ -148,43 +182,43 @@ func checkFilepath(p string, invalidMsg string) error {
 }
 
 func (s *SDK) ToitCompile(ctx context.Context, args ...string) *exec.Cmd {
-	return exec.CommandContext(ctx, s.ToitPath(), append([]string{"compile"}, args...)...)
+	return exec.CommandContext(ctx, s.ToitCompilePath(), args...)
 }
 
 func (s *SDK) ToitRun(ctx context.Context, args ...string) *exec.Cmd {
-	return exec.CommandContext(ctx, s.ToitPath(), append([]string{"run", "--"}, args...)...)
+	return exec.CommandContext(ctx, s.ToitRunPath(), args...)
 }
 
 func (s *SDK) ToitLsp(ctx context.Context, args []string) *exec.Cmd {
-	return exec.CommandContext(ctx, s.ToitPath(), append([]string{"tool", "lsp"}, args...)...)
+	return exec.CommandContext(ctx, s.ToitLspPath(), args...)
 }
 
 func (s *SDK) AssetsTool(ctx context.Context, args ...string) *exec.Cmd {
-	return exec.CommandContext(ctx, s.ToitPath(), append([]string{"tool", "assets"}, args...)...)
+	return exec.CommandContext(ctx, s.AssetsToolPath(), args...)
 }
 
 func (s *SDK) FirmwareTool(ctx context.Context, args ...string) *exec.Cmd {
-	return exec.CommandContext(ctx, s.ToitPath(), append([]string{"tool", "firmware"}, args...)...)
+	return exec.CommandContext(ctx, s.FirmwareToolPath(), args...)
 }
 
 func (s *SDK) SnapshotToImage(ctx context.Context, args ...string) *exec.Cmd {
-	return exec.CommandContext(ctx, s.ToitPath(), append([]string{"tool", "snapshot-to-image"}, args...)...)
+	return exec.CommandContext(ctx, s.SnapshotToImagePath(), args...)
 }
 
 func (s *SDK) SystemMessage(ctx context.Context, args ...string) *exec.Cmd {
-	return exec.CommandContext(ctx, s.ToitPath(), append([]string{"decode"}, args...)...)
+	return exec.CommandContext(ctx, s.SystemMessagePath(), args...)
 }
 
 func (s *SDK) Stacktrace(ctx context.Context, args ...string) *exec.Cmd {
-	return exec.CommandContext(ctx, s.ToitPath(), append([]string{"tool", "esp", "stacktrace"}, args...)...)
+	return exec.CommandContext(ctx, s.StacktracePath(), args...)
 }
 
 func (s *SDK) Compile(ctx context.Context, snapshot string, entrypoint string, optimizationLevel int) error {
 	var buildSnap *exec.Cmd
 	if optimizationLevel >= 0 {
-		buildSnap = s.ToitCompile(ctx, "--snapshot", "-o", snapshot, "-O"+strconv.Itoa(optimizationLevel), entrypoint)
+		buildSnap = s.ToitCompile(ctx, "-w", snapshot, "-O"+strconv.Itoa(optimizationLevel), entrypoint)
 	} else {
-		buildSnap = s.ToitCompile(ctx, "--snapshot", "-o", snapshot, entrypoint)
+		buildSnap = s.ToitCompile(ctx, "-w", snapshot, entrypoint)
 	}
 	buildSnap.Stderr = os.Stderr
 	buildSnap.Stdout = os.Stdout


### PR DESCRIPTION
This reverts commit 24a15fcc18d44e61cc0d2e7db3cd017a4bb99140.