### PR TITLE
Use the given IP if there is one.

### DIFF
--- a/cmd/jag/commands/device_network.go
+++ b/cmd/jag/commands/device_network.go
@@ -226,6 +226,8 @@ func ScanNetwork(ctx context.Context, ds deviceSelect, port uint) ([]Device, err
 		} else if dev == nil {
 			return nil, fmt.Errorf("invalid identify response")
 		}
+		// Use the provided address. This way we can tunnel through the device.
+		dev.address = "http://" + addr
 		return []Device{*dev}, nil
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced device identification process by allowing the device to tunnel to a specified address during network scanning.

- **Bug Fixes**
	- Improved handling of network requests and responses without altering existing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->