### PR TITLE
Fix `jag simulate`.

### DIFF
--- a/cmd/jag/commands/simulate.go
+++ b/cmd/jag/commands/simulate.go
@@ -73,7 +73,7 @@ func SimulateCmd() *cobra.Command {
 				decoder.decode(pretty, plain)
 			}()
 
-			simCmd := sdk.ToitRun(ctx, snapshot, strconv.Itoa(int(port)), id.String(), name)
+			simCmd := sdk.ToitRunSnapshot(ctx, snapshot, strconv.Itoa(int(port)), id.String(), name)
 			simCmd.Stderr = os.Stderr
 			simCmd.Stdout = outWriter
 			return simCmd.Run()

--- a/cmd/jag/commands/util.go
+++ b/cmd/jag/commands/util.go
@@ -155,6 +155,10 @@ func (s *SDK) ToitRun(ctx context.Context, args ...string) *exec.Cmd {
 	return exec.CommandContext(ctx, s.ToitPath(), append([]string{"run", "--"}, args...)...)
 }
 
+func (s *SDK) ToitRunSnapshot(ctx context.Context, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, s.ToitPath(), args...)
+}
+
 func (s *SDK) ToitLsp(ctx context.Context, args []string) *exec.Cmd {
 	return exec.CommandContext(ctx, s.ToitPath(), append([]string{"tool", "lsp"}, args...)...)
 }


### PR DESCRIPTION
The `toit` executable currently doesn't run snapshots with `toit run`. As a workaround just call `toit <snapshot>` instead.

Fixes #572.