### PR TITLE
Print elapsed send time as part of jag run

### DIFF
--- a/cmd/jag/commands/run.go
+++ b/cmd/jag/commands/run.go
@@ -380,7 +380,7 @@ func sendCodeFromFile(
 		cmd.SilenceUsage = true
 		return err
 	}
-
+	startSend := time.Now()
 	if err := device.SendCode(ctx, sdk, request, b, headersMap); err != nil {
 		fmt.Println("Error:", err)
 		// We just printed the error.
@@ -389,7 +389,8 @@ func sendCodeFromFile(
 		cmd.SilenceUsage = true
 		return err
 	}
-	fmt.Printf("Success: Sent %dKB code to '%s'\n", len(b)/1024, device.Name())
+	elapsed := time.Since(startSend)
+	fmt.Printf("Success: Sent %dKB code to '%s' in %.2fs\n", len(b)/1024, device.Name(), elapsed.Seconds())
 	return nil
 }
 


### PR DESCRIPTION
Tested and output looks like this

```
Scanning for  device with address: '192.168.68.65'
Running './httpmsg-raw.toit' on 'third-world' ...
Success: Sent 127KB code to 'third-world' in 4.88s
```