### PR TITLE
Provide a 'jag toit ...' pass-through.

### DIFF
--- a/cmd/jag/commands/toit.go
+++ b/cmd/jag/commands/toit.go
@@ -13,8 +13,67 @@ import (
 func ToitCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "toit",
-		Short: "Use 'toit lsp' and other extras through Jaguar",
+		Short: "Run 'toit' commands through Jaguar",
+		Long: "Run the downloaded 'toit' command with the given arguments.\n\n" +
+			"Calling 'jag toit --help' provides the help of 'toit'.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+
+			// Skip "lsp" which is handled by a dedicated command.
+			if args[0] == "lsp" {
+				return nil
+			}
+
+			ctx := cmd.Context()
+			sdk, err := GetSDK(ctx)
+			if err != nil {
+				return err
+			}
+
+			passThrough := sdk.PassThrough(ctx, args)
+			passThrough.Stdin = os.Stdin
+			passThrough.Stdout = os.Stdout
+			passThrough.Stderr = os.Stderr
+			return passThrough.Run()
+		},
+		// Don't print usage on error since we're passing through.
+		SilenceUsage: true,
+		// Disable Cobra's flag parsing entirely to pass all flags through
+		DisableFlagParsing: true,
+		// Disable help flag so it gets passed through to the underlying command
+		DisableAutoGenTag: true,
 	}
+
+	// Add custom help function that passes through to the underlying command
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		// Check if we have a valid context
+		ctx := cmd.Context()
+		if ctx == nil {
+			// Fall back to showing our own help if context is nil
+			// This happens when using `jag help toit` instead of `jag toit --help`
+			cmd.Println(cmd.Long)
+			return
+		}
+
+		// Get the SDK only if we have a valid context
+		sdk, err := GetSDK(ctx)
+		if err != nil {
+			cmd.PrintErr(err)
+			return
+		}
+
+		// Combine the command args with the help flag
+		args = append(args, "-h")
+		passThrough := sdk.PassThrough(ctx, args)
+		passThrough.Stdin = os.Stdin
+		passThrough.Stdout = os.Stdout
+		passThrough.Stderr = os.Stderr
+		if err := passThrough.Run(); err != nil {
+			cmd.PrintErr(err)
+		}
+	})
 
 	cmd.AddCommand(
 		ToitLspCmd(),
@@ -26,7 +85,6 @@ func ToitLspCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "lsp",
 		Short:        "Start the Toit LSP server",
-		Long:         "Start the Toit LSP server.\n\nUse 'jag toit lsp -- --help' for detailed help.",
 		SilenceUsage: true,
 		Hidden:       true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/jag/commands/util.go
+++ b/cmd/jag/commands/util.go
@@ -233,6 +233,10 @@ func (s *SDK) Build(ctx context.Context, device Device, snapshotPath string, ass
 	return os.ReadFile(image.Name())
 }
 
+func (s *SDK) PassThrough(ctx context.Context, args []string) *exec.Cmd {
+	return exec.CommandContext(ctx, s.ToitPath(), args...)
+}
+
 type gzipReader struct {
 	*gzip.Reader
 	inner io.ReadCloser


### PR DESCRIPTION
This makes it possible to use any of the `toit` commands through Jaguar without knowing where Jaguar downloaded the SDK.