### PR TITLE
Use WINGET_PAT secret instead of WINGET_JAGUAR_SECRET.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Update manifest
         if: (github.event_name == 'release') && (runner.os == 'Windows')
         run: |
-          .\wingetcreate.exe update Toit.Jaguar -s -v ${{ steps.version.outputs.version }} -u https://github.com/toitlang/jaguar/releases/download/${{ github.event.release.tag_name }}/jag_installer_x64.exe -t ${{ secrets.WINGET_JAGUAR_PAT }}
+          .\wingetcreate.exe update Toit.Jaguar -s -v ${{ steps.version.outputs.version }} -u https://github.com/toitlang/jaguar/releases/download/${{ github.event.release.tag_name }}/jag_installer_x64.exe -t ${{ secrets.WINGET_PAT }}
 
       - name: Prepare Linux release upload
         if: (github.event_name == 'release') && (matrix.container == 'ubuntu-22.04')


### PR DESCRIPTION
We are moving the secret to the organization level so that other repos can use the secret too.