### PR TITLE
jag monitor: Ctrl+C shutting down gracefully

### DIFF
--- a/cmd/jag/commands/monitor.go
+++ b/cmd/jag/commands/monitor.go
@@ -74,16 +74,6 @@ func MonitorCmd() *cobra.Command {
 				<-signalChan
 				fmt.Printf("\nInterrupt received, shutting down gracefully...\n")
 				cancel()
-
-				if dev != nil {
-					dev.Close()
-				}
-
-				// Give the decoder a moment to detect the cancellation
-				// If it's still running, force exit
-				time.Sleep(250 * time.Millisecond)
-				fmt.Printf("Exiting...\n")
-				os.Exit(0)
 			}()
 
 			if !attach {
@@ -123,10 +113,6 @@ func MonitorCmd() *cobra.Command {
 			case err := <-done:
 				return err
 			case <-ctx.Done():
-				// Context was cancelled (by signal), clean up and exit
-				if dev != nil {
-					dev.Close()
-				}
 				return ctx.Err()
 			}
 		},

--- a/cmd/jag/commands/monitor.go
+++ b/cmd/jag/commands/monitor.go
@@ -69,7 +69,7 @@ func MonitorCmd() *cobra.Command {
 			signalChan := make(chan os.Signal, 1)
 			signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
 
-			// Handle signals in a separate goroutine
+			// Handle signals in a separate goroutine.
 			go func() {
 				<-signalChan
 				fmt.Printf("\nInterrupt received, shutting down gracefully...\n")
@@ -100,7 +100,7 @@ func MonitorCmd() *cobra.Command {
 				return err
 			}
 
-			// Create a context-aware decoder that can be interrupted
+			// Create a context-aware decoder that can be interrupted.
 			decoder := NewDecoder(scanner, ctx, envelope)
 			done := make(chan error, 1)
 			go func() {
@@ -108,7 +108,7 @@ func MonitorCmd() *cobra.Command {
 				done <- scanner.Err()
 			}()
 
-			// Wait for either completion or context cancellation
+			// Wait for either completion or context cancellation.
 			select {
 			case err := <-done:
 				return err


### PR DESCRIPTION
Make a cancellable context that is passed into the decoder, rather than using that of the cmd.
And handle signals in a separate goroutine explicitly closing the port and waiting for things nicely