### PR TITLE
Add --interval for container installation

### DIFF
--- a/cmd/jag/commands/device.go
+++ b/cmd/jag/commands/device.go
@@ -16,12 +16,13 @@ import (
 )
 
 const (
-	JaguarDeviceIDHeader         = "X-Jaguar-Device-ID"
-	JaguarSDKVersionHeader       = "X-Jaguar-SDK-Version"
-	JaguarWifiDisabledHeader     = "X-Jaguar-Wifi-Disabled"
-	JaguarContainerNameHeader    = "X-Jaguar-Container-Name"
-	JaguarContainerTimeoutHeader = "X-Jaguar-Container-Timeout"
-	JaguarCRC32Header            = "X-Jaguar-CRC32"
+	JaguarDeviceIDHeader          = "X-Jaguar-Device-ID"
+	JaguarSDKVersionHeader        = "X-Jaguar-SDK-Version"
+	JaguarWifiDisabledHeader      = "X-Jaguar-Wifi-Disabled"
+	JaguarContainerNameHeader     = "X-Jaguar-Container-Name"
+	JaguarContainerTimeoutHeader  = "X-Jaguar-Container-Timeout"
+	JaguarContainerIntervalHeader = "X-Jaguar-Container-Interval"
+	JaguarCRC32Header             = "X-Jaguar-CRC32"
 )
 
 type Device interface {

--- a/cmd/jag/commands/proxy_network.go
+++ b/cmd/jag/commands/proxy_network.go
@@ -26,15 +26,17 @@ const (
 	// The URL for the style sheet.
 	styleURL = "https://toitlang.github.io/jaguar/device-files/style.css"
 
-	headerDeviceId         = "X-Jaguar-Device-ID"
-	headerSdkVersion       = "X-Jaguar-SDK-Version"
-	headerWifiDisabled     = "X-Jaguar-Wifi-Disabled"
-	headerContainerName    = "X-Jaguar-Container-Name"
-	headerContainerTimeout = "X-Jaguar-Container-Timeout"
+	headerDeviceId          = "X-Jaguar-Device-ID"
+	headerSdkVersion        = "X-Jaguar-SDK-Version"
+	headerWifiDisabled      = "X-Jaguar-Wifi-Disabled"
+	headerContainerName     = "X-Jaguar-Container-Name"
+	headerContainerTimeout  = "X-Jaguar-Container-Timeout"
+	headerContainerInterval = "X-Jaguar-Container-Interval"
 
 	defineJagDisabled = "jag.disabled"
 	defineJagWifi     = "jag.wifi"
 	defineJagTimeout  = "jag.timeout"
+	defineJagInterval = "jag.interval"
 
 	udpIdentifyPort = 1990
 	// Broadcast.
@@ -287,6 +289,11 @@ func extractDefines(r *http.Request) map[string]interface{} {
 		if timeout, err := strconv.Atoi(val); err == nil {
 			defines[defineJagTimeout] = timeout
 		}
+	}
+	if r.Header.Get(headerContainerInterval) != "" {
+		val := r.Header.Get(headerContainerInterval)
+		// Pass the interval string directly
+		defines[defineJagInterval] = val
 	}
 	return defines
 }

--- a/cmd/jag/commands/run.go
+++ b/cmd/jag/commands/run.go
@@ -356,6 +356,17 @@ func sendCodeFromFile(
 				default:
 					return fmt.Errorf("jag.timeout must be a string or an int")
 				}
+			} else if key == "jag.interval" {
+				switch converted := value.(type) {
+				case string:
+					_, err := time.ParseDuration(converted)
+					if err != nil {
+						return fmt.Errorf("cannot parse jag.interval ('%s') as a duration", converted)
+					}
+					headersMap[JaguarContainerIntervalHeader] = converted
+				default:
+					return fmt.Errorf("jag.interval must be a duration string (e.g., '30s', '5m', '1h')")
+				}
 			} else {
 				return fmt.Errorf("unsupported Jaguar define: %s", key)
 			}

--- a/src/network.toit
+++ b/src/network.toit
@@ -20,12 +20,13 @@ IDENTIFY-PORT    ::= 1990
 IDENTIFY-ADDRESS ::= net.IpAddress.parse "255.255.255.255"
 STATUS-OK-JSON   ::= """{ "status": "OK" }"""
 
-HEADER-DEVICE-ID         ::= "X-Jaguar-Device-ID"
-HEADER-SDK-VERSION       ::= "X-Jaguar-SDK-Version"
-HEADER-WIFI-DISABLED     ::= "X-Jaguar-Wifi-Disabled"
-HEADER-CONTAINER-NAME    ::= "X-Jaguar-Container-Name"
-HEADER-CONTAINER-TIMEOUT ::= "X-Jaguar-Container-Timeout"
-HEADER-CRC32             ::= "X-Jaguar-CRC32"
+HEADER-DEVICE-ID          ::= "X-Jaguar-Device-ID"
+HEADER-SDK-VERSION        ::= "X-Jaguar-SDK-Version"
+HEADER-WIFI-DISABLED      ::= "X-Jaguar-Wifi-Disabled"
+HEADER-CONTAINER-NAME     ::= "X-Jaguar-Container-Name"
+HEADER-CONTAINER-TIMEOUT  ::= "X-Jaguar-Container-Timeout"
+HEADER-CONTAINER-INTERVAL ::= "X-Jaguar-Container-Interval"
+HEADER-CRC32              ::= "X-Jaguar-CRC32"
 
 // Assets for the mini-webpage that the device serves up on $HTTP_PORT.
 CHIP-IMAGE ::= "https://toitlang.github.io/jaguar/device-files/chip.svg"
@@ -234,6 +235,8 @@ class EndpointHttp implements Endpoint:
     if header := headers.single HEADER-CONTAINER-TIMEOUT:
       timeout := int.parse header --on-error=: null
       if timeout: defines[JAG-TIMEOUT] = timeout
+    if header := headers.single HEADER-CONTAINER-INTERVAL:
+      defines[JAG-INTERVAL] = header
     return defines
 
   respond-ok writer/http.ResponseWriter -> none:


### PR DESCRIPTION
This mimics the interval options that currently exist
within artemis.
You can pass a time period, which jaguar will use to ensure
that your container is running. If it isn't running its started
again.
