### PR TITLE
udp broadcast disable option

### DIFF
--- a/src/jaguar.toit
+++ b/src/jaguar.toit
@@ -30,6 +30,7 @@ interface Endpoint:
 JAG-WIFI ::= "jag.wifi"
 JAG-TIMEOUT  ::= "jag.timeout"
 JAG-INTERVAL ::= "jag.interval"
+JAG-DISABLE-UDP ::= "jag.disable-udp"
 
 logger ::= log.Logger log.INFO-LEVEL log.DefaultTarget --name="jaguar"
 flash-mutex ::= monitor.Mutex

--- a/src/network.toit
+++ b/src/network.toit
@@ -27,6 +27,7 @@ HEADER-CONTAINER-NAME     ::= "X-Jaguar-Container-Name"
 HEADER-CONTAINER-TIMEOUT  ::= "X-Jaguar-Container-Timeout"
 HEADER-CONTAINER-INTERVAL ::= "X-Jaguar-Container-Interval"
 HEADER-CRC32              ::= "X-Jaguar-CRC32"
+HEADER-DISABLE-UDP       ::= "X-Jaguar-Disable-UDP"
 
 // Assets for the mini-webpage that the device serves up on $HTTP_PORT.
 CHIP-IMAGE ::= "https://toitlang.github.io/jaguar/device-files/chip.svg"
@@ -57,12 +58,7 @@ class EndpointHttp implements Endpoint:
 
       request-mutex := monitor.Mutex
 
-      // A task that broadcasts the device identity via UDP and one that
-      // serves incoming HTTP requests.
-      // We run the tasks in a group so if one of them terminates, we take the other
-      // one down and clean up nicely.
-      Task.group --required=1 [
-        :: broadcast-identity network device address,
+      tasks := [
         :: serve-incoming-requests socket device address request-mutex,
         // If the call to the network-manager monitor returns, it will terminate the
         // task and thus shut down the whole group.
@@ -73,6 +69,11 @@ class EndpointHttp implements Endpoint:
             socket.close
             socket = null
       ]
+
+      if not (device.config.get JAG-DISABLE-UDP) == true:
+        tasks.add (:: broadcast-identity network device address)
+
+      Task.group --required=1 tasks
     finally:
       if socket: socket.close
       network.close
@@ -232,6 +233,8 @@ class EndpointHttp implements Endpoint:
     defines := {:}
     if headers.single HEADER-WIFI-DISABLED:
       defines[JAG-WIFI] = false
+    if headers.single HEADER-DISABLE-UDP:
+      defines[JAG-DISABLE-UDP] = true
     if header := headers.single HEADER-CONTAINER-TIMEOUT:
       timeout := int.parse header --on-error=: null
       if timeout: defines[JAG-TIMEOUT] = timeout

--- a/src/network.toit
+++ b/src/network.toit
@@ -70,7 +70,7 @@ class EndpointHttp implements Endpoint:
             socket = null
       ]
 
-      if not (device.config.get JAG-DISABLE-UDP) == true:
+      if not device.config.get JAG-DISABLE-UDP:
         tasks.add (:: broadcast-identity network device address)
 
       Task.group --required=1 tasks


### PR DESCRIPTION
Add an option to disable UDP broadcast.
The UDP broadcast can sometimes end up causing
errors while many other BLE and WiFi activities,
such as scans are ongoing.
In some cases, users may want to just disable them,
so provide that option.
