### PR TITLE
Override the partition table for the ESP32-C6.

### DIFF
--- a/cmd/jag/commands/firmware.go
+++ b/cmd/jag/commands/firmware.go
@@ -74,9 +74,9 @@ func FirmwareUpdateCmd() *cobra.Command {
 
 			// We get a new ID for the device, so entries in the device flash stored
 			// by an older version are invalidated.
-			return withFirmware(cmd, args, nil, device, func(newID string, envelopeFile *os.File, config map[string]interface{}) error {
+			return withFirmware(cmd, args, nil, device, func(newID string, envelopeFile *os.File, config map[string]interface{}, partitionArgs []string) error {
 
-				firmwareBin, err := ExtractFirmwareBin(ctx, sdk, envelopeFile.Name(), config)
+				firmwareBin, err := ExtractFirmwareBin(ctx, sdk, envelopeFile.Name(), config, partitionArgs...)
 				if err != nil {
 					return err
 				}
@@ -140,14 +140,14 @@ func FirmwareExtractCmd() *cobra.Command {
 				return fmt.Errorf("missing output file")
 			}
 
-			return withFirmware(cmd, args, nil, nil, func(newID string, envelopeFile *os.File, config map[string]interface{}) error {
+			return withFirmware(cmd, args, nil, nil, func(newID string, envelopeFile *os.File, config map[string]interface{}, partitionArgs []string) error {
 
 				sdk, err := GetSDK(ctx)
 				if err != nil {
 					return err
 				}
 
-				imageFile, err := ExtractFirmware(ctx, sdk, envelopeFile.Name(), "image", config)
+				imageFile, err := ExtractFirmware(ctx, sdk, envelopeFile.Name(), "image", config, partitionArgs...)
 				if err != nil {
 					return err
 				}

--- a/cmd/jag/commands/firmware_flash.go
+++ b/cmd/jag/commands/firmware_flash.go
@@ -19,7 +19,7 @@ import (
 	"github.com/toitlang/jaguar/cmd/jag/directory"
 )
 
-type callback func(id string, envelopeFile *os.File, config map[string]interface{}) error
+type callback func(id string, envelopeFile *os.File, config map[string]interface{}, partitionArgs []string) error
 type probeChip func(ctx context.Context, sdk *SDK) (string, error)
 
 func addFirmwareFlashFlags(cmd *cobra.Command, nameHelp string) {
@@ -171,7 +171,13 @@ func withFirmware(cmd *cobra.Command, args []string, probeChip probeChip, device
 
 	config := deviceOptions.GetConfig()
 
-	return fun(id.String(), envelopeFile, config)
+	partitionArgs, cleanupPartitions, err := partitionOverrideArgs(chip)
+	if err != nil {
+		return err
+	}
+	defer cleanupPartitions()
+
+	return fun(id.String(), envelopeFile, config, partitionArgs)
 }
 
 func BuildFirmwareEnvelope(ctx context.Context, envelope EnvelopeOptions, device DeviceOptions, uartEndpointOptions map[string]interface{}) (*os.File, error) {
@@ -307,7 +313,7 @@ func (d DeviceOptions) GetConfig() map[string]interface{} {
 	}
 }
 
-func ExtractFirmwareBin(ctx context.Context, sdk *SDK, envelopePath string, config map[string]interface{}) (*os.File, error) {
+func ExtractFirmwareBin(ctx context.Context, sdk *SDK, envelopePath string, config map[string]interface{}, extraArgs ...string) (*os.File, error) {
 	binaryFile, err := os.CreateTemp("", "firmware.bin.*")
 	if err != nil {
 		return nil, err
@@ -318,6 +324,7 @@ func ExtractFirmwareBin(ctx context.Context, sdk *SDK, envelopePath string, conf
 		"--format=binary",
 		"-o", binaryFile.Name(),
 	}
+	arguments = append(arguments, extraArgs...)
 
 	if err := runFirmwareToolWithConfig(ctx, sdk, envelopePath, config, arguments...); err != nil {
 		binaryFile.Close()
@@ -326,12 +333,14 @@ func ExtractFirmwareBin(ctx context.Context, sdk *SDK, envelopePath string, conf
 	return binaryFile, nil
 }
 
-func ExtractFirmware(ctx context.Context, sdk *SDK, envelopePath string, format string, config map[string]interface{}) (*os.File, error) {
+func ExtractFirmware(ctx context.Context, sdk *SDK, envelopePath string, format string, config map[string]interface{}, extraArgs ...string) (*os.File, error) {
 	outputFile, err := os.CreateTemp("", "firmware-"+format+".*")
 	if err != nil {
 		return nil, err
 	}
-	if err := runFirmwareToolWithConfig(ctx, sdk, envelopePath, config, "extract", "--format", format, "-o", outputFile.Name()); err != nil {
+	arguments := []string{"extract", "--format", format, "-o", outputFile.Name()}
+	arguments = append(arguments, extraArgs...)
+	if err := runFirmwareToolWithConfig(ctx, sdk, envelopePath, config, arguments...); err != nil {
 		outputFile.Close()
 		return nil, err
 	}

--- a/cmd/jag/commands/flash.go
+++ b/cmd/jag/commands/flash.go
@@ -58,7 +58,7 @@ func FlashCmd() *cobra.Command {
 				}
 				return result, err
 			}
-			return withFirmware(cmd, args, probeChipType, nil, func(id string, envelopeFile *os.File, config map[string]interface{}) error {
+			return withFirmware(cmd, args, probeChipType, nil, func(id string, envelopeFile *os.File, config map[string]interface{}, partitionArgs []string) error {
 
 				sdk, err := GetSDK(ctx)
 				if err != nil {
@@ -70,6 +70,7 @@ func FlashCmd() *cobra.Command {
 					"--port", port,
 					"--baud", strconv.Itoa(int(baud)),
 				}
+				flashArguments = append(flashArguments, partitionArgs...)
 
 				// Golang equivalent of #ifdef Windows.  We skip this
 				// because the whole uucp group issue does not affect

--- a/cmd/jag/commands/partitions.go
+++ b/cmd/jag/commands/partitions.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+package commands
+
+import (
+	"embed"
+	"os"
+)
+
+//go:embed partitions/*.csv
+var partitionTables embed.FS
+
+// chipsWithPartitionOverride maps a chip type to the embedded partition table
+// that Jaguar should use instead of the one shipped in the envelope.
+//
+// This is a workaround for SDK v2.0.0-alpha.194, where the firmware image for
+// the ESP32-C6 grew past the 0x1b0000 OTA partitions of the envelope's default
+// table. See partitions/esp32c6.csv for details. Remove the affected entries
+// once the envelopes/SDK ship large enough OTA partitions.
+var chipsWithPartitionOverride = map[string]string{
+	"esp32c6": "partitions/esp32c6.csv",
+}
+
+// partitionOverrideArgs returns the firmware-tool arguments that override the
+// partition table for the given chip, or nil if no override is needed. When a
+// non-nil slice is returned, the caller must invoke cleanup once the arguments
+// are no longer needed to remove the temporary file.
+func partitionOverrideArgs(chip string) (args []string, cleanup func(), err error) {
+	noop := func() {}
+
+	asset, ok := chipsWithPartitionOverride[chip]
+	if !ok {
+		return nil, noop, nil
+	}
+
+	contents, err := partitionTables.ReadFile(asset)
+	if err != nil {
+		return nil, noop, err
+	}
+
+	file, err := os.CreateTemp("", "*.partitions.csv")
+	if err != nil {
+		return nil, noop, err
+	}
+	if _, err := file.Write(contents); err != nil {
+		file.Close()
+		os.Remove(file.Name())
+		return nil, noop, err
+	}
+	if err := file.Close(); err != nil {
+		os.Remove(file.Name())
+		return nil, noop, err
+	}
+
+	cleanup = func() { os.Remove(file.Name()) }
+	return []string{"--partitions", file.Name()}, cleanup, nil
+}

--- a/cmd/jag/commands/partitions/esp32c6.csv
+++ b/cmd/jag/commands/partitions/esp32c6.csv
@@ -1,0 +1,25 @@
+# Copyright (C) 2026 Toit contributors.
+#
+# Use of this source code is governed by an MIT-style license that can be
+# found in the LICENSE file.
+
+# Jaguar partition table for the ESP32-C6.
+#
+# Workaround for SDK v2.0.0-alpha.194, where the firmware image for the C6
+# (1781232 bytes) no longer fits in the 0x1b0000 OTA partitions of the
+# envelope's default table. We grow each OTA partition to 0x1c0000 and shrink
+# the (Jaguar-unused) 'programs' partition to keep the total at 4MB.
+#
+# This override should be removed once the envelopes/SDK ship a C6 table with
+# large enough OTA partitions.
+
+# Name,   Type, SubType,  Offset,    Size
+# bootloader,,  ,         0x001000,  0x007000
+# partitions,,  ,         0x008000,  0x000c00
+secure,   0x42, 0x00,     0x009000,  0x004000,
+otadata,  data, ota,              ,  0x002000,
+phy_init, data, phy,              ,  0x001000,
+ota_0,    app,  ota_0,            ,  0x1c0000,
+ota_1,    app,  ota_1,            ,  0x1c0000,
+nvs,      data, nvs,              ,  0x010000,
+programs, 0x40, 0x00,             ,  0x060000, encrypted


### PR DESCRIPTION
As of SDK v2.0.0-alpha.194 the firmware image for the ESP32-C6 (1781232 bytes) no longer fits in the 0x1b0000 OTA partitions of the envelope's default partition table, so flashing and extracting fail with "Firmware is too big to fit in designated partition". The other chips (esp32, c3, s2, s3) still fit their 0x1a0000 partitions and are unaffected.

Ship a per-chip partition-table override and pass it to the firmware tool via '--partitions'. For the C6 the OTA partitions are grown to 0x1c0000 and the (Jaguar-unused) 'programs' partition is shrunk to 0x060000 to keep the total at 4MB. The override is applied consistently across 'flash', 'firmware extract', and 'firmware update'.

This is a workaround until the envelopes/SDK ship a C6 partition table with large enough OTA partitions.