### PR TITLE
Fix device ID/SDK version not persisting after firmware update.

### DIFF
--- a/cmd/jag/commands/device.go
+++ b/cmd/jag/commands/device.go
@@ -90,11 +90,11 @@ func (d DeviceBase) Address() string {
 	return d.address
 }
 
-func (d DeviceBase) SetID(id string) {
+func (d *DeviceBase) SetID(id string) {
 	d.id = id
 }
 
-func (d DeviceBase) SetSDKVersion(version string) {
+func (d *DeviceBase) SetSDKVersion(version string) {
 	d.sdkVersion = version
 }
 

--- a/cmd/jag/commands/device_network.go
+++ b/cmd/jag/commands/device_network.go
@@ -238,7 +238,7 @@ func Identify(ctx context.Context, ds deviceSelect) ([]Device, error) {
 	}
 	// Use the provided address. This way we can tunnel through the device.
 	dev.address = "http://" + addr
-	return []Device{*dev}, nil
+	return []Device{dev}, nil
 }
 
 func ScanNetwork(ctx context.Context, ds deviceSelect, port uint) ([]Device, error) {
@@ -279,7 +279,7 @@ looping:
 		if err != nil {
 			fmt.Println("Failed to parse identify", err)
 		} else if dev != nil {
-			devices[dev.Address()] = *dev
+			devices[dev.Address()] = dev
 		}
 	}
 


### PR DESCRIPTION
`SetID` and `SetSDKVersion` setters previously had value receivers. This would cause the ID to not get updated after a `jag firmware update` until device gets rescanned.