### PR TITLE
Implement watching print/log/trace output over the network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ download-sdk: $(BUILD_DIR)/$(JAG_BINARY)
 	$(BUILD_DIR)/$(JAG_BINARY) --no-analytics setup sdk $(BUILD_SDK_DIR)
 
 .PHONY: test
+test: test-toit
 test: $(BUILD_DIR)/$(JAG_BINARY)
 	@# For now just try to extract images for all chips.
 	@for chip in esp32 esp32c3 esp32c6 esp32s2 esp32s3; do \
@@ -121,4 +122,14 @@ test: $(BUILD_DIR)/$(JAG_BINARY)
 				firmware extract $$chip \
 				-o $$tmp_dir/$$chip.snapshot; \
 		rm -rf $$tmp_dir; \
+	done
+
+####################################
+# Rules for the Toit-side unit tests
+####################################
+.PHONY: test-toit
+test-toit: install-dependencies
+	@for test in $$(find tests -name '*-test.toit'); do \
+		echo "Running $$test"; \
+		$(SDK_PATH)/bin/toit$(EXE_SUFFIX) run "$$test" || exit 1; \
 	done

--- a/cmd/jag/commands/device.go
+++ b/cmd/jag/commands/device.go
@@ -21,6 +21,7 @@ const (
 	JaguarContainerTimeoutHeader  = "X-Jaguar-Container-Timeout"
 	JaguarContainerIntervalHeader = "X-Jaguar-Container-Interval"
 	JaguarCRC32Header             = "X-Jaguar-CRC32"
+	JaguarLogConfigHeader         = "X-Jaguar-Log-Config"
 )
 
 type Device interface {
@@ -38,6 +39,8 @@ type Device interface {
 
 	Ping(ctx context.Context, sdk *SDK) bool
 	SendCode(ctx context.Context, sdk *SDK, request string, b []byte, headersMap map[string]string) error
+	PollLog(ctx context.Context, cursor int, containers []string) (*LogPollResponse, error)
+	ConfigureLog(ctx context.Context, config map[string]interface{}) error
 	ContainerList(ctx context.Context, sdk *SDK) (map[string]string, error)
 	ContainerUninstall(ctx context.Context, sdk *SDK, name string) error
 	UpdateFirmware(ctx context.Context, sdk *SDK, b []byte) error

--- a/cmd/jag/commands/device_log.go
+++ b/cmd/jag/commands/device_log.go
@@ -1,0 +1,190 @@
+// Copyright (C) 2026 Toitware ApS. All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/toitware/ubjson"
+)
+
+// LogEntry is one captured line of device output, as returned by GET /log. On
+// the wire each entry is a fixed-order array [seq, container, type, level, text]
+// (the device omits the field names to roughly halve the encoded size); see
+// logEntryFromArray for the decoding.
+type LogEntry struct {
+	Seq       int
+	Container string
+	Type      string
+	// Level can be nullable, in case of print/trace/exit entries.
+	Level *int
+	Text  string
+}
+
+// logEntryFromArray decodes the device's positional [seq, container, type,
+// level, text] array into a LogEntry. Numbers arrive as int64 (ubjson) or
+// float64 (json), so the conversions accept both.
+func logEntryFromArray(raw interface{}) (LogEntry, error) {
+	// Number of elements in the wire array form of a LogEntry.
+	const logEntryArity = 5
+
+	arr, ok := raw.([]interface{})
+	if !ok || len(arr) != logEntryArity {
+		return LogEntry{}, fmt.Errorf("malformed log entry, expected %d-element array: %v", logEntryArity, raw)
+	}
+
+	var err error
+	entry := LogEntry{}
+	if entry.Seq, err = decodeInt(arr, 0); err != nil {
+		return entry, err
+	}
+	if entry.Container, err = decodeString(arr, 1); err != nil {
+		return entry, err
+	}
+	if entry.Type, err = decodeString(arr, 2); err != nil {
+		return entry, err
+	}
+	// Level can be null, in case of print/trace/exit.
+	if arr[3] != nil {
+		level, err := decodeInt(arr, 3)
+		if err != nil {
+			return entry, err
+		}
+		entry.Level = &level
+	}
+	if entry.Text, err = decodeString(arr, 4); err != nil {
+		return entry, err
+	}
+
+	return entry, nil
+}
+
+// decodeInt reads element i as an int. Numbers arrive as int64 (ubjson) or float64 (json).
+func decodeInt(arr []interface{}, i int) (int, error) {
+	switch n := arr[i].(type) {
+	case int64:
+		return int(n), nil
+	case float64:
+		return int(n), nil
+	default:
+		return 0, fmt.Errorf("log entry field %d: expected number, got %T", i, arr[i])
+	}
+}
+
+func decodeString(arr []interface{}, i int) (string, error) {
+	s, ok := arr[i].(string)
+	if !ok {
+		return "", fmt.Errorf("log entry field %d: expected string, got %T", i, arr[i])
+	}
+	return s, nil
+}
+
+// LogPollResponse is the decoded body of a GET /log response.
+type LogPollResponse struct {
+	// Next is the cursor to pass to the following poll. The device caps each
+	// response, so Next may be short of Head; polling again with it pages through
+	// the backlog.
+	Next    int
+	Head    int
+	Oldest  int
+	Entries []LogEntry
+}
+
+// logPollWire mirrors the GET /log body before the entries are turned into
+// LogEntry values: entries arrive as positional arrays (see LogEntry), so they
+// are decoded generically here and converted by logEntryFromArray.
+type logPollWire struct {
+	Next    int           `json:"next"`
+	Head    int           `json:"head"`
+	Oldest  int           `json:"oldest"`
+	Entries []interface{} `json:"entries"`
+}
+
+// PollLog drains GET /log, filtered to the given container names (the device
+// stamps each entry with its producing container: empty for `/run` programs,
+// the install name for `/install`-ed containers). An empty slice means no
+// filter; the empty string matches the anonymous `/run` programs.
+func (d DeviceNetwork) PollLog(ctx context.Context, cursor int, containers []string) (*LogPollResponse, error) {
+	// Repeat the "containers" parameter once per name. An empty slice sends none
+	// (no filter); an empty-string entry matches the anonymous `/run` programs,
+	// which is exactly what `run -m` wants.
+	var pathBuilder strings.Builder
+	fmt.Fprintf(&pathBuilder, "/log?cursor=%d", cursor)
+	for _, container := range containers {
+		fmt.Fprintf(&pathBuilder, "&containers=%s", url.QueryEscape(container))
+	}
+	req, err := d.newRequest(ctx, "GET", pathBuilder.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set(JaguarDeviceIDHeader, d.ID())
+	// The device skips the SDK-version check for /log. Its handler negotiates on
+	// Accept; ask for the more compact ubjson.
+	req.Header.Set("Accept", "application/ubjson")
+	// Close the connection after each poll. The device serves connections one at
+	// a time (max_tasks=1), so a kept-alive poll connection would pin its listen
+	// task across polls and starve concurrent /run and /ping requests.
+	req.Close = true
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("got non-OK from device: %s", res.Status)
+	}
+
+	var wire logPollWire
+	if err := ubjson.Unmarshal(body, &wire); err != nil {
+		return nil, err
+	}
+	parsed := &LogPollResponse{Next: wire.Next, Head: wire.Head, Oldest: wire.Oldest}
+	for _, raw := range wire.Entries {
+		entry, err := logEntryFromArray(raw)
+		if err != nil {
+			return nil, err
+		}
+		parsed.Entries = append(parsed.Entries, entry)
+	}
+	return parsed, nil
+}
+
+// ConfigureLog applies a log-buffer configuration via PUT /log/configure. The
+// config map mirrors the /log/configure body (e.g. {"enabled": true,
+// "buffer_size": 4096, "min_level": "INFO"}); missing fields leave the matching
+// device setting unchanged.
+func (d DeviceNetwork) ConfigureLog(ctx context.Context, config map[string]interface{}) error {
+	body, err := json.Marshal(config)
+	if err != nil {
+		return err
+	}
+	req, err := d.newRequest(ctx, "PUT", "/log/configure", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set(JaguarDeviceIDHeader, d.ID())
+	// The device serves one connection at a time; don't pin it across the call.
+	req.Close = true
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	io.ReadAll(res.Body) // Avoid closing connection prematurely.
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("got non-OK from device: %s", res.Status)
+	}
+	return nil
+}

--- a/cmd/jag/commands/device_network.go
+++ b/cmd/jag/commands/device_network.go
@@ -175,9 +175,6 @@ func (d DeviceNetwork) ContainerUninstall(ctx context.Context, sdk *SDK, name st
 	}
 
 	io.ReadAll(res.Body) // Avoid closing connection prematurely.
-	if err != nil {
-		return err
-	}
 	if res.StatusCode != http.StatusOK {
 		return fmt.Errorf("got non-OK from device: %s", res.Status)
 	}

--- a/cmd/jag/commands/monitor.go
+++ b/cmd/jag/commands/monitor.go
@@ -12,161 +12,79 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/spf13/cobra"
-	"go.bug.st/serial"
 )
 
 func MonitorCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "monitor",
-		Short:        "Monitor the serial output of an ESP32",
+		Use:   "monitor",
+		Short: "Monitor the serial output of an ESP32",
+		Long: "Monitor the output of an ESP32.\n\n" +
+			"With no subcommand, this defaults to 'jag monitor uart' for backwards compatibility.",
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, cancel := context.WithCancel(cmd.Context())
-			defer cancel()
-
-			port, err := cmd.Flags().GetString("port")
-			if err != nil {
-				return err
-			}
-
-			if port, err = CheckPort(port); err != nil {
-				return err
-			}
-
-			baud, err := cmd.Flags().GetUint("baud")
-			if err != nil {
-				return err
-			}
-
-			attach, err := cmd.Flags().GetBool("attach")
-			if err != nil {
-				return err
-			}
-
-			pretty, err := cmd.Flags().GetBool("force-pretty")
-			if err != nil {
-				return err
-			}
-
-			plain, err := cmd.Flags().GetBool("force-plain")
-			if err != nil {
-				return err
-			}
-
-			fmt.Printf("Starting serial monitor of port '%s' ...\n", port)
-			dev, err := serialOpen(port, int(baud))
-			if err != nil {
-				return err
-			}
-			defer dev.Close()
-
-			signalChan := make(chan os.Signal, 1)
-			signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
-
-			// Handle signals in a separate goroutine.
-			go func() {
-				<-signalChan
-				fmt.Printf("\nInterrupt received, shutting down gracefully...\n")
-				cancel()
-			}()
-
-			if !attach {
-				dev.Reboot()
-			}
-
-			var logReader io.Reader = dev
-
-			shouldProxy, err := cmd.Flags().GetBool("proxy")
-			if err != nil {
-				return err
-			}
-
-			if shouldProxy {
-				ch1, ch2 := multiplexReader(dev)
-				logReader = ch1
-				go runUartProxy(dev, ch2)
-			}
-
-			scanner := bufio.NewScanner(logReader)
-
-			envelope, err := cmd.Flags().GetString("envelope")
-			if err != nil {
-				return err
-			}
-
-			// Create a context-aware decoder that can be interrupted.
-			decoder := NewDecoder(scanner, ctx, envelope)
-			done := make(chan error, 1)
-			go func() {
-				decoder.decode(pretty, plain)
-				done <- scanner.Err()
-			}()
-
-			// Wait for either completion or context cancellation.
-			select {
-			case err := <-done:
-				return err
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-		},
+		RunE:         runMonitorUart,
 	}
 
-	cmd.Flags().StringP("port", "p", ConfiguredPort(), "port to monitor")
-	cmd.Flags().BoolP("attach", "a", false, "attach to the serial output without rebooting it")
-	cmd.Flags().BoolP("force-pretty", "r", false, "force output to use terminal graphics")
-	cmd.Flags().BoolP("force-plain", "l", false, "force output to use plain ASCII text")
-	cmd.Flags().Uint("baud", 115200, "the baud rate for serial monitoring")
-	cmd.Flags().Bool("proxy", false, "proxy the connected device to the local network")
-	cmd.Flags().String("envelope", "", "name or path of the firmware envelope")
+	addUartFlags(cmd)
+	cmd.AddCommand(MonitorUartCmd())
+	cmd.AddCommand(MonitorNetworkCmd())
 	return cmd
 }
 
-func serialOpen(port string, baud int) (*serialPort, error) {
-	dev, err := serial.Open(port, &serial.Mode{
-		BaudRate: baud,
-		// Make sure we don't accidentally reset the device on open.
-		InitialStatusBits: &serial.ModemOutputBits{
-			RTS: true,
-			DTR: true,
-		},
-	})
-	if os.IsNotExist(err) {
-		return nil, fmt.Errorf("the port '%s' was not found", port)
-	}
+// cancelOnSignal calls cancel and prints message when the user hits Ctrl-C.
+func cancelOnSignal(cancel context.CancelFunc, message string) {
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-signalChan
+		fmt.Fprintf(os.Stderr, "\n%s\n", message)
+		cancel()
+	}()
+}
+
+// decoderFlags holds the shared monitor output flags that configure the
+// decoder, common to the uart and network monitors.
+type decoderFlags struct {
+	pretty   bool
+	plain    bool
+	envelope string
+}
+
+// parseDecoderFlags reads the shared --force-pretty / --force-plain / --envelope
+// flags off cmd.
+func parseDecoderFlags(cmd *cobra.Command) (decoderFlags, error) {
+	pretty, err := cmd.Flags().GetBool("force-pretty")
 	if err != nil {
-		return nil, err
+		return decoderFlags{}, err
 	}
-
-	return &serialPort{dev}, err
-}
-
-type serialPort struct {
-	serial.Port
-}
-
-func (s serialPort) Read(buf []byte) (n int, err error) {
-	n, err = s.Port.Read(buf)
-	if err == nil && n == 0 {
-		return 0, io.ErrUnexpectedEOF
+	plain, err := cmd.Flags().GetBool("force-plain")
+	if err != nil {
+		return decoderFlags{}, err
 	}
-	return n, err
-}
-
-func (s *serialPort) Close() error {
-	if s.Port != nil {
-		return s.Port.Close()
+	envelope, err := cmd.Flags().GetString("envelope")
+	if err != nil {
+		return decoderFlags{}, err
 	}
-	return nil
+	return decoderFlags{pretty: pretty, plain: plain, envelope: envelope}, nil
 }
 
-func (s *serialPort) Reboot() {
-	s.SetDTR(false)
-	s.SetRTS(true)
-	time.Sleep(100 * time.Millisecond)
-	s.SetRTS(false)
+// decodeReader streams reader through the monitor decoder until the program's
+// output ends or ctx is canceled. It returns any error from the scanner;
+// cancellation (Ctrl-C or detach) yields nil.
+func decodeReader(ctx context.Context, reader io.Reader, flags decoderFlags) error {
+	scanner := bufio.NewScanner(reader)
+	decoder := NewDecoder(scanner, ctx, flags.envelope)
+	done := make(chan error, 1)
+	go func() {
+		decoder.decode(flags.pretty, flags.plain)
+		done <- scanner.Err()
+	}()
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return nil
+	}
 }

--- a/cmd/jag/commands/monitor_network.go
+++ b/cmd/jag/commands/monitor_network.go
@@ -1,0 +1,189 @@
+// Copyright (C) 2026 Toitware ApS. All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func MonitorNetworkCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "network",
+		Short:        "Monitor the output of an ESP32 over the network",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE:         runMonitorNetwork,
+	}
+	cmd.Flags().StringP("device", "d", "", "use device with a given name, id, or address")
+	cmd.Flags().StringArray("container", nil, "only show output from the named container (repeatable; '_run_' matches anonymous 'run' programs)")
+	cmd.Flags().BoolP("force-pretty", "r", false, "force output to use terminal graphics")
+	cmd.Flags().BoolP("force-plain", "l", false, "force output to use plain ASCII text")
+	cmd.Flags().String("envelope", "", "name or path of the firmware envelope")
+	cmd.Flags().Uint("log-buffer-size", 0, "resize the device log buffer to this many bytes (default: leave unchanged)")
+	cmd.Flags().String("min-log-level", "", "minimum level captured in the device log buffer (TRACE, DEBUG, INFO, WARN, ERROR, FATAL; default: leave unchanged)")
+	return cmd
+}
+
+func runMonitorNetwork(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	deviceSelect, err := parseDeviceFlag(cmd)
+	if err != nil {
+		return err
+	}
+
+	containers, err := cmd.Flags().GetStringArray("container")
+	if err != nil {
+		return err
+	}
+
+	sdk, err := GetSDK(ctx)
+	if err != nil {
+		return err
+	}
+
+	device, err := GetDevice(ctx, sdk, true, deviceSelect)
+	if err != nil {
+		return err
+	}
+
+	// Monitoring over the network always enables capture so the device records
+	// output into its log ring. Only resize the buffer or change the min level
+	// when asked; otherwise leave the device's current settings untouched.
+	logConfig := map[string]interface{}{"enabled": true}
+	if cmd.Flags().Changed("log-buffer-size") {
+		bufferSize, err := cmd.Flags().GetUint("log-buffer-size")
+		if err != nil {
+			return err
+		}
+		logConfig["buffer_size"] = bufferSize
+	}
+	if cmd.Flags().Changed("min-log-level") {
+		minLevel, err := cmd.Flags().GetString("min-log-level")
+		if err != nil {
+			return err
+		}
+		logConfig["min_level"] = minLevel
+	}
+	if err := device.ConfigureLog(ctx, logConfig); err != nil {
+		return err
+	}
+
+	// The standalone monitor keeps watching across program exits/restarts and
+	// replays whatever is already buffered (startCursor 0); only `run -m`
+	// (monitorRunNetwork) stops once its run is done and starts past the buffer.
+	return monitorNetwork(cmd, device, containers, false, 0)
+}
+
+// logEntryTypeExit is the entry type the device uses to mark that a captured
+// container stopped; its text is the exit code.
+const logEntryTypeExit = "exit"
+
+// logHead returns the device's current log head (the latest captured seq). Seqs
+// are global across containers, so a later poll starting from this value skips
+// whatever is already buffered and shows only output produced afterwards.
+func logHead(ctx context.Context, device Device) (int, error) {
+	// No container filter: head is global, and matching any container lets the
+	// device's long-poll return at once if the ring holds anything at all.
+	resp, err := device.PollLog(ctx, 0, nil)
+	if err != nil {
+		return 0, err
+	}
+	return resp.Head, nil
+}
+
+// monitorRunNetwork polls GET /log filtered to the given container names and
+// feeds this run's output through the shared decoder until the program exits or
+// the user detaches. startCursor is the seq to start past (see logHead).
+func monitorRunNetwork(cmd *cobra.Command, device Device, containers []string, startCursor int) error {
+	return monitorNetwork(cmd, device, containers, true, startCursor)
+}
+
+// monitorNetwork polls GET /log filtered to the given container names and feeds
+// the output through the shared decoder until the user detaches. It starts from
+// startCursor (0 replays the whole buffer). When stopOnExit is set it also
+// returns once a captured container exits (used by `run -m`); otherwise it keeps
+// watching across exits and restarts.
+func monitorNetwork(cmd *cobra.Command, device Device, containers []string, stopOnExit bool, startCursor int) error {
+	ctx, cancel := context.WithCancel(cmd.Context())
+	defer cancel()
+	cancelOnSignal(cancel, "Detaching (program keeps running on the device)...")
+
+	flags, err := parseDecoderFlags(cmd)
+	if err != nil {
+		return err
+	}
+
+	// The poll loop writes reconstructed lines into the pipe; decodeReader reads
+	// them out the other end and decodes them, exactly like the serial monitor.
+	// Propagate the poll loop's error (e.g. lost connection) to the decoder side
+	// via the pipe; a nil error closes it with plain EOF.
+	reader, writer := io.Pipe()
+	go func() {
+		writer.CloseWithError(pollLogLoop(ctx, device, containers, writer, stopOnExit, startCursor))
+	}()
+	return decodeReader(ctx, reader, flags)
+}
+
+func pollLogLoop(ctx context.Context, device Device, containers []string, out io.Writer, stopOnExit bool, startCursor int) error {
+	cursor := startCursor
+	firstPoll := true
+	consecutiveErrors := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return nil // Detached.
+		default:
+		}
+
+		resp, err := device.PollLog(ctx, cursor, containers)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil // Canceled while polling.
+			}
+			consecutiveErrors++
+			if consecutiveErrors > 20 {
+				return fmt.Errorf("lost connection to device: %w", err)
+			}
+			time.Sleep(250 * time.Millisecond)
+			continue
+		}
+		consecutiveErrors = 0
+
+		// Drop detection (filter-agnostic): if entries we had not read yet were
+		// evicted from the ring, note it. Skip on the first poll (initial sync).
+		if !firstPoll && cursor < resp.Oldest-1 {
+			dropped := resp.Oldest - 1 - cursor
+			fmt.Fprintf(out, "[... %d line(s) dropped ...]\n", dropped)
+		}
+		firstPoll = false
+
+		for _, entry := range resp.Entries {
+			if entry.Type == logEntryTypeExit {
+				// Emit the marker inline at the exit's real position so several
+				// buffered exits (e.g. a cursor-0 replay of past runs) each show
+				// up where they happened instead of collapsing into one.
+				exitCode, _ := strconv.Atoi(entry.Text)
+				fmt.Fprintf(out, "[ program stopped - exit code %d ]\n", exitCode)
+				// `run -m` watches a single program, so it stops at the first
+				// exit; the standalone monitor keeps following across restarts.
+				if stopOnExit {
+					return nil
+				}
+				continue
+			}
+			fmt.Fprintf(out, "%s\n", entry.Text)
+		}
+		// Advance by Next, not Head: the device caps each response, so Next may
+		// trail Head; the next poll then pages through the rest of the backlog.
+		cursor = resp.Next
+	}
+}

--- a/cmd/jag/commands/monitor_uart.go
+++ b/cmd/jag/commands/monitor_uart.go
@@ -1,0 +1,196 @@
+// Copyright (C) 2026 Toitware ApS. All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.bug.st/serial"
+)
+
+func MonitorUartCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "uart",
+		Short:        "Monitor the serial (UART) output of an ESP32",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE:         runMonitorUart,
+	}
+	addUartFlags(cmd)
+	return cmd
+}
+
+func addUartFlags(cmd *cobra.Command) {
+	cmd.Flags().StringP("port", "p", ConfiguredPort(), "port to monitor")
+	cmd.Flags().BoolP("attach", "a", false, "attach to the serial output without rebooting it")
+	cmd.Flags().BoolP("force-pretty", "r", false, "force output to use terminal graphics")
+	cmd.Flags().BoolP("force-plain", "l", false, "force output to use plain ASCII text")
+	cmd.Flags().Uint("baud", 115200, "the baud rate for serial monitoring")
+	cmd.Flags().Bool("proxy", false, "proxy the connected device to the local network")
+	cmd.Flags().String("envelope", "", "name or path of the firmware envelope")
+}
+
+func runMonitorUart(cmd *cobra.Command, args []string) error {
+	opts, err := parseSerialMonitorFlags(cmd, "port", "baud", true, true)
+	if err != nil {
+		return err
+	}
+	return monitorSerialPort(cmd.Context(), opts, nil)
+}
+
+// parseSerialMonitorFlags reads the serial-monitor flags off cmd into a
+// serialMonitorOptions. The port and baud flag names differ between callers
+// (`monitor` uses "port"/"baud", `run` uses "monitor-port"/"monitor-baud"), so
+// they are passed in. hasAttach and hasProxy say whether the command exposes
+// those optional flags; `run` omits both, so it always attaches in place
+// (reboot stays false, since it just started the program) and never proxies.
+func parseSerialMonitorFlags(cmd *cobra.Command, portFlag, baudFlag string, hasAttach, hasProxy bool) (serialMonitorOptions, error) {
+	port, err := cmd.Flags().GetString(portFlag)
+	if err != nil {
+		return serialMonitorOptions{}, err
+	}
+
+	baud, err := cmd.Flags().GetUint(baudFlag)
+	if err != nil {
+		return serialMonitorOptions{}, err
+	}
+
+	reboot := false
+	if hasAttach {
+		attach, err := cmd.Flags().GetBool("attach")
+		if err != nil {
+			return serialMonitorOptions{}, err
+		}
+		reboot = !attach
+	}
+
+	proxy := false
+	if hasProxy {
+		proxy, err = cmd.Flags().GetBool("proxy")
+		if err != nil {
+			return serialMonitorOptions{}, err
+		}
+	}
+
+	decoder, err := parseDecoderFlags(cmd)
+	if err != nil {
+		return serialMonitorOptions{}, err
+	}
+
+	return serialMonitorOptions{
+		port:    port,
+		baud:    int(baud),
+		reboot:  reboot,
+		proxy:   proxy,
+		decoder: decoder,
+	}, nil
+}
+
+// serialMonitorOptions configures monitorSerialPort.
+type serialMonitorOptions struct {
+	port    string
+	baud    int
+	reboot  bool         // pulse the reset line before reading; false attaches in place
+	proxy   bool         // tee the device onto the local-network proxy
+	decoder decoderFlags // shared output flags for the decoder
+}
+
+// monitorSerialPort opens the serial port and streams its output through the
+// decoder until the program ends or the user detaches.
+//
+// afterOpen, if non-nil, runs once the port is open but before streaming starts.
+// `run -m -p` uses it to send the program only after the port is listening, so
+// the program's first lines aren't lost in the upload window.
+func monitorSerialPort(ctx context.Context, opts serialMonitorOptions, afterOpen func() error) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	port, err := CheckPort(opts.port)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Reading serial output from '%s' ...\n", port)
+	dev, err := serialOpen(port, opts.baud)
+	if err != nil {
+		return err
+	}
+	defer dev.Close()
+
+	cancelOnSignal(cancel, "Detaching...")
+
+	if opts.reboot {
+		dev.Reboot()
+	}
+
+	// When proxy is set, tee the device onto the local-network proxy and feed
+	// the decoder the other tap; otherwise read the device directly.
+	var logReader io.Reader = dev
+	if opts.proxy {
+		ch1, ch2 := multiplexReader(dev)
+		go runUartProxy(dev, ch2)
+		logReader = ch1
+	}
+
+	// Send the program (if any) now that the port is open; its output will be
+	// buffered by the OS until decodeReader starts draining it just below.
+	if afterOpen != nil {
+		if err := afterOpen(); err != nil {
+			return err
+		}
+	}
+
+	return decodeReader(ctx, logReader, opts.decoder)
+}
+
+func serialOpen(port string, baud int) (*serialPort, error) {
+	dev, err := serial.Open(port, &serial.Mode{
+		BaudRate: baud,
+		// Make sure we don't accidentally reset the device on open.
+		InitialStatusBits: &serial.ModemOutputBits{
+			RTS: true,
+			DTR: true,
+		},
+	})
+	if os.IsNotExist(err) {
+		return nil, fmt.Errorf("the port '%s' was not found", port)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &serialPort{dev}, err
+}
+
+type serialPort struct {
+	serial.Port
+}
+
+func (s serialPort) Read(buf []byte) (n int, err error) {
+	n, err = s.Port.Read(buf)
+	if err == nil && n == 0 {
+		return 0, io.ErrUnexpectedEOF
+	}
+	return n, err
+}
+
+func (s *serialPort) Close() error {
+	if s.Port != nil {
+		return s.Port.Close()
+	}
+	return nil
+}
+
+func (s *serialPort) Reboot() {
+	s.SetDTR(false)
+	s.SetRTS(true)
+	time.Sleep(100 * time.Millisecond)
+	s.SetRTS(false)
+}

--- a/cmd/jag/commands/run.go
+++ b/cmd/jag/commands/run.go
@@ -113,6 +113,23 @@ func RunCmd() *cobra.Command {
 				return err
 			}
 
+			// `-m` streams this run's output; `-p` reads it from a serial port
+			// (and implies `-m`), otherwise monitoring happens over the network.
+			monitor, _ := cmd.Flags().GetBool("monitor")
+			monitorSerial := cmd.Flags().Changed("monitor-port")
+			if monitorSerial {
+				monitor = true
+
+				// The log buffer (and thus its size and min level) only exists on the
+				// network path; serial reads the UART directly.
+				if cmd.Flags().Changed("log-buffer-size") {
+					return fmt.Errorf("--log-buffer-size is not supported when monitoring over serial (the log buffer is only used over the network)")
+				}
+				if cmd.Flags().Changed("min-log-level") {
+					return fmt.Errorf("--min-log-level is not supported when monitoring over serial (the log buffer is only used over the network)")
+				}
+			}
+
 			optimizationLevel := -1
 			if cmd.Flags().Changed("optimization-level") {
 				optimizationLevel, err = cmd.Flags().GetInt("optimization-level")
@@ -122,6 +139,9 @@ func RunCmd() *cobra.Command {
 			}
 
 			if name, ok := deviceSelect.(deviceNameSelect); ok && string(name) == "host" {
+				if monitor {
+					return fmt.Errorf("--monitor/-m is not supported with '-d host' (output already goes to this terminal)")
+				}
 				if cmd.Flags().Changed("define") {
 					return fmt.Errorf("--define/-D is not yet supported when running on host")
 				}
@@ -168,6 +188,17 @@ func RunCmd() *cobra.Command {
 				return err
 			}
 
+			if monitor {
+				if monitorSerial {
+					return RunFileAndMonitorSerial(cmd, device, sdk, entrypoint, defines, programAssetsPath, optimizationLevel)
+				}
+				// Network monitoring is unreachable if the run tears down WiFi.
+				if wifi, ok := defines["jag.wifi"].(bool); ok && !wifi {
+					return fmt.Errorf("can't monitor over the network with -D jag.wifi=false; attach over serial with 'jag run -m -p <port>'")
+				}
+				return RunFileAndMonitorNetwork(cmd, device, sdk, entrypoint, defines, programAssetsPath, optimizationLevel)
+			}
+
 			return RunFile(cmd, device, sdk, entrypoint, defines, programAssetsPath, optimizationLevel)
 		},
 	}
@@ -177,6 +208,14 @@ func RunCmd() *cobra.Command {
 	cmd.Flags().StringArrayP("define", "D", nil, "define settings to control run on device")
 	cmd.Flags().String("assets", "", "attach assets to the program")
 	cmd.Flags().IntP("optimization-level", "O", 1, "optimization level")
+	cmd.Flags().BoolP("monitor", "m", false, "after starting, stream this run's output until it exits or Ctrl-C is pressed")
+	cmd.Flags().StringP("monitor-port", "p", "", "read the run's output from this serial port instead of the network (implies -m)")
+	cmd.Flags().Uint("monitor-baud", 115200, "the baud rate when monitoring over serial")
+	cmd.Flags().Bool("force-pretty", false, "force monitor output to use terminal graphics")
+	cmd.Flags().Bool("force-plain", false, "force monitor output to use plain ASCII text")
+	cmd.Flags().String("envelope", "", "firmware envelope used to decode native crashes while monitoring")
+	cmd.Flags().Uint("log-buffer-size", 4096, "size in bytes of the device log buffer used when monitoring over the network")
+	cmd.Flags().String("min-log-level", "INFO", "minimum level captured in the device log buffer (TRACE, DEBUG, INFO, WARN, ERROR, FATAL); network monitoring only")
 	return cmd
 }
 
@@ -219,7 +258,79 @@ func RunFile(
 	assetsPath string,
 	optimizationLevel int) error {
 	fmt.Printf("Running '%s' on '%s' ...\n", path, device.Name())
-	return sendCodeFromFile(cmd, device, sdk, "/run", path, "", defines, assetsPath, optimizationLevel)
+	return sendCodeFromFile(cmd, device, sdk, "/run", path, "", defines, assetsPath, optimizationLevel, "")
+}
+
+// RunFileAndMonitorNetwork runs the file with capture enabled and then streams
+// this run's output (filtered to its container, which for a `/run` is the
+// anonymous empty name) through the decoder until the program exits or the user
+// detaches with Ctrl-C.
+func RunFileAndMonitorNetwork(
+	cmd *cobra.Command,
+	device Device,
+	sdk *SDK,
+	path string,
+	defines map[string]interface{},
+	assetsPath string,
+	optimizationLevel int) error {
+	fmt.Printf("Running '%s' on '%s' ...\n", path, device.Name())
+	// Capture the current log head before starting so the monitor shows only
+	// this run's output instead of replaying whatever is already buffered on the
+	// device.
+	startCursor, err := logHead(cmd.Context(), device)
+	if err != nil {
+		return err
+	}
+	// `run` always pins the capture config so the device sizes its log ring and
+	// sets the min level before this run's first print.
+	bufferSize, err := cmd.Flags().GetUint("log-buffer-size")
+	if err != nil {
+		return err
+	}
+	minLevel, err := cmd.Flags().GetString("min-log-level")
+	if err != nil {
+		return err
+	}
+	logConfig, err := json.Marshal(map[string]interface{}{
+		"enabled":     true,
+		"buffer_size": bufferSize,
+		"min_level":   minLevel,
+	})
+	if err != nil {
+		return err
+	}
+	if err := sendCodeFromFile(cmd, device, sdk, "/run", path, "", defines, assetsPath, optimizationLevel, string(logConfig)); err != nil {
+		return err
+	}
+	// A `/run` container is captured under the empty name, so filter on that.
+	return monitorRunNetwork(cmd, device, []string{""}, startCursor)
+}
+
+// RunFileAndMonitorSerial runs the file and then attaches to the serial port to
+// stream output. Serial shows everything from the attach point (it can't filter
+// by container) and never reboots the device.
+func RunFileAndMonitorSerial(
+	cmd *cobra.Command,
+	device Device,
+	sdk *SDK,
+	path string,
+	defines map[string]interface{},
+	assetsPath string,
+	optimizationLevel int) error {
+	fmt.Printf("Running '%s' on '%s' ...\n", path, device.Name())
+	// `run` reads the port from --monitor-port and has no --attach: the program
+	// was just started, so stream from the attach point without rebooting.
+	opts, err := parseSerialMonitorFlags(cmd, "monitor-port", "monitor-baud", false, false)
+	if err != nil {
+		return err
+	}
+	// Open the serial port first, then send the program: opening it before the
+	// upload means the program's first lines are already buffered by the OS when
+	// it starts printing, instead of being lost during the ~1s upload window.
+	// Serial reads the UART directly, so no capture header is needed.
+	return monitorSerialPort(cmd.Context(), opts, func() error {
+		return sendCodeFromFile(cmd, device, sdk, "/run", path, "", defines, assetsPath, optimizationLevel, "")
+	})
 }
 
 func InstallFile(
@@ -232,7 +343,7 @@ func InstallFile(
 	assetsPath string,
 	optimizationLevel int) error {
 	fmt.Printf("Installing container '%s' from '%s' on '%s' ...\n", name, path, device.Name())
-	return sendCodeFromFile(cmd, device, sdk, "/install", path, name, defines, assetsPath, optimizationLevel)
+	return sendCodeFromFile(cmd, device, sdk, "/install", path, name, defines, assetsPath, optimizationLevel, "")
 }
 
 func sendCodeFromFile(
@@ -244,7 +355,8 @@ func sendCodeFromFile(
 	name string,
 	defines map[string]interface{},
 	assetsPath string,
-	optimizationLevel int) error {
+	optimizationLevel int,
+	logConfig string) error {
 
 	ctx := cmd.Context()
 	snapshotsStateDir, err := directory.GetSnapshotsStatePath()
@@ -328,6 +440,9 @@ func sendCodeFromFile(
 	// and the ones we send along as assets.
 	headersMap := make(map[string]string)
 	headersMap[JaguarContainerNameHeader] = name
+	if logConfig != "" {
+		headersMap[JaguarLogConfigHeader] = logConfig
+	}
 	assetsMap := make(map[string]interface{})
 	for key, value := range defines {
 		if strings.HasPrefix(key, "jag.") {
@@ -395,7 +510,8 @@ func sendCodeFromFile(
 		return err
 	}
 	startSend := time.Now()
-	if err := device.SendCode(ctx, sdk, request, b, headersMap); err != nil {
+	err = device.SendCode(ctx, sdk, request, b, headersMap)
+	if err != nil {
 		fmt.Println("Error:", err)
 		// We just printed the error.
 		// Mark the command as silent to avoid printing the error twice.

--- a/src/jaguar.toit
+++ b/src/jaguar.toit
@@ -17,6 +17,7 @@ import system.containers
 import system.firmware
 
 import .container-registry
+import .log.buffer
 import .network
 import .schedule
 import .uart
@@ -92,6 +93,10 @@ wifi-manager / NetworkManager ::= NetworkManager
 // The installed and named containers are kept in a registry backed
 // by the flash (on the device).
 registry_ / ContainerRegistry ::= ContainerRegistry
+
+// The network-visible capture of print/log/trace output. Off by default; turned
+// on by a `run -m`/`install -m`, or the first `GET /log`.
+log-buffer_ / LogBuffer ::= LogBuffer
 
 main arguments:
   device := Device.parse arguments
@@ -326,11 +331,22 @@ start-image_ -> bool
   // Once the program has terminated we need to cancel the callback.
   cancelation-token := null
 
+  // The started container's gid, filled in once we have it. The on-stopped
+  // callback reads it lazily (it only runs at a later yield point, by which
+  // time it is set).
+  container-gid := -1
+
   // Start the image, but don't wait for it to run to completion.
   container := containers.start image --on-stopped=:: | code/int |
     started-containers_.remove image
     if cancelation-token:
       scheduled-callbacks.remove cancelation-token
+
+    // Mark the container's exit in the log ring so a network monitor
+    // (e.g. `run -m`) filtering on this container knows the program finished,
+    // then drop the gid->name mapping now that the container is gone.
+    log-buffer_.append-exit --gid=container-gid --code=code
+    log-buffer_.unregister-container --gid=container-gid
 
     if code == 0:
       logger.info "$nick stopped"
@@ -348,6 +364,10 @@ start-image_ -> bool
           if current-entry:
             logger.info "restarting container '$name' (interval restart)"
             start-image image "restarted" name current-entry[1]
+  container-gid = container.gid
+  // Register before the container gets a chance to run (no yield until then) so
+  // its very first print already resolves to the right name.
+  log-buffer_.register-container --gid=container-gid --name=name
   started-containers_[image] = container
 
   if timeout:

--- a/src/log/buffer.toit
+++ b/src/log/buffer.toit
@@ -1,0 +1,272 @@
+// Copyright (C) 2026 Toitware ApS. All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+import log
+import monitor
+
+import .capture
+import .entry
+
+// Default size in bytes of the ring buffer's budget: the sum over all held
+// entries of each entry's field contents plus a fixed per-entry overhead (see
+// $ENTRY-OVERHEAD_), which approximates the encoded size of the entries.
+DEFAULT-BUFFER-SIZE ::= 4096
+// Log entries below this level never enter the ring (the capture floor). Print
+// output has no level and is always captured.
+DEFAULT-MIN-LEVEL ::= log.INFO-LEVEL
+// The bounded hold for a `GET /log` long-poll.
+DEFAULT-HOLD ::= Duration --ms=500
+// The most bytes (summed $LogEntry.size) a single `drain` returns. Caps the peak
+// contiguous allocation needed to encode one `GET /log` response, so a large
+// $LogBuffer.buffer-size_ can't make a single response exhaust the device heap.
+// A client pages through a longer backlog by polling again with the returned
+// "next" cursor. A single entry larger than this is still returned on its own,
+// so an oversized line can never stall the stream.
+MAX-DRAIN-BYTES ::= 1024
+// The filter value that selects the anonymous `/run` programs, which are
+// captured under the empty container name.
+RUN-CONTAINER-SENTINEL ::= "_run_"
+
+/**
+The global capture ring buffer and its service providers.
+
+A single chronological ring mirrors the serial console: all monitored
+  containers are interleaved in time order. Entries are evicted oldest-first once
+  the total size (see $LogEntry.size) exceeds $buffer-size_.
+
+Capture is off by default and has zero overhead until something opts in: a
+  `run -m`/`install -m` or the first `GET /log`. Once enabled, the providers and
+  ring stay around until the next reboot, which is the only safe lifetime: a
+  container binds to whatever provider exists at its first `print`, so we must
+  never unregister a provider while a bound container is still alive.
+*/
+class LogBuffer:
+  // Configuration.
+  buffer-size_/int := DEFAULT-BUFFER-SIZE
+  min-level_/int := DEFAULT-MIN-LEVEL
+
+  // Ring state.
+  entries_/Deque ::= Deque  // Of LogEntry, in seq order.
+  total-bytes_/int := 0
+  // The seq the next appended entry will get. Entry seqs are 1-based and
+  // monotonic; 'head' (the highest seq ever assigned) is next-seq_ - 1.
+  next-seq_/int := 1
+
+  // Raised whenever an entry is appended, to wake `/log` long-polls early.
+  signal_/monitor.Signal ::= monitor.Signal
+
+  enabled_/bool := false
+  provider_/CaptureProvider? := null
+
+  // Maps a running container's system gid to the name jaguar started it under
+  // (empty for an anonymous `/run` program). Populated as containers start and
+  // dropped as they stop, so the capture handlers - which only see a gid - can
+  // stamp each entry with its producing container's name. A gid absent from the
+  // map (e.g. a system container that predates capture) renders as "?".
+  container-names_/Map ::= {:}  // Of gid/int -> name/string.
+
+  /**
+  Enables capture.
+
+  Registers the print/log/trace providers (if not already registered) so that
+    containers started from now on bind to them, and lets appends accumulate in
+    the ring. Idempotent.
+
+  The providers are never unregistered, even across a later $disable: a container
+    resolves and caches its print/log service provider on its first use, so
+    unregistering while a bound container is still alive would make that
+    container's next `print` hit a dead RPC channel and throw into user code.
+    Staying registered until reboot is the only safe lifetime - $disable instead
+    leaves them installed but turns them into pass-throughs.
+  */
+  enable -> none:
+    if enabled_: return
+    enabled_ = true
+    if not provider_:
+      provider_ = CaptureProvider this
+      provider_.install
+
+  /**
+  Disables capture and frees the ring.
+
+  Drops all retained entries and stops appending new ones, reclaiming the
+    buffer's memory. The providers stay installed (see $enable) and keep writing
+    to the UART, so this is equivalent to capture never having been set up apart
+    from the still-registered - but now pass-through - providers. Idempotent.
+  */
+  disable -> none:
+    if not enabled_: return
+    enabled_ = false
+    entries_.clear
+    total-bytes_ = 0
+
+  /** Whether capture is currently enabled. */
+  enabled -> bool:
+    return enabled_
+
+  /** The highest seq ever assigned (0 if nothing has been captured). */
+  head_ -> int:
+    return next-seq_ - 1
+
+  /** The lowest seq still in the ring (or head_ + 1 if the ring is empty). */
+  oldest_ -> int:
+    return entries_.is-empty ? next-seq_ : (entries_.first as LogEntry).seq
+
+  /**
+  Registers that the container with the given $gid was started under $name.
+
+  $name is null for an anonymous `/run` program and is stored as the empty
+    string. The mapping lets the capture handlers, which only see a gid, stamp
+    each entry with its producing container's name.
+  */
+  register-container --gid/int --name/string? -> none:
+    container-names_[gid] = name or ""
+
+  /** Drops the gid->name mapping for a stopped container. */
+  unregister-container --gid/int -> none:
+    container-names_.remove gid
+
+  /** The name registered for $gid, or "?" if jaguar did not start it. */
+  name-for-gid_ gid/int -> string:
+    return container-names_.get gid --if-absent=: "?"
+
+  append-print message/string --gid/int -> none:
+    if not enabled_: return
+    append_ TYPE-PRINT null message --gid=gid
+
+  append-log level/int text/string --gid/int -> none:
+    if not enabled_: return
+    if level < min-level_: return
+    append_ TYPE-LOG level text --gid=gid
+
+  append-trace text/string --gid/int -> none:
+    if not enabled_: return
+    append_ TYPE-TRACE null text --gid=gid
+
+  /**
+  Records that the container with the given $gid stopped with exit $code.
+
+  No-op when capture is not enabled (nothing is draining the ring, so there is
+    no reason to grow it).
+  */
+  append-exit --gid/int --code/int -> none:
+    if not enabled_: return
+    append_ TYPE-EXIT null "$code" --gid=gid
+
+  append_ type/string level/int? text/string --gid/int -> none:
+    entry := LogEntry next-seq_++ (name-for-gid_ gid) type level text
+    entries_.add entry
+    total-bytes_ += entry.size
+    evict_
+    signal_.raise
+
+  /** Evicts whole oldest entries until the payload fits $buffer-size_. */
+  evict_ -> none:
+    // Always keep the most recently added entry, even if it alone is larger
+    // than the configured budget.
+    while total-bytes_ > buffer-size_ and entries_.size > 1:
+      removed/LogEntry := entries_.remove-first
+      total-bytes_ -= removed.size
+
+  /**
+  Drains the ring for the given $cursor.
+
+  Returns at most $MAX-DRAIN-BYTES worth of entries with seq greater than $cursor
+    (optionally filtered to the $containers names). Long-polls up to $max-hold for
+    a matching entry to appear, waking early as soon as one does.
+
+  The returned map carries:
+  - "entries": the (possibly capped) batch, as $LogEntry.to-list arrays.
+  - "next": the cursor to pass to the next drain. When the batch was capped it is
+    the seq of the last returned entry, so the next drain continues the backlog;
+    otherwise the whole ring was scanned and it is $head_, which also skips past
+    any trailing non-matching entries.
+  - "head": the global high-water seq, for a fresh `run -m` to start past the
+    existing buffer (see $head_).
+  - "oldest": the lowest seq still in the ring, for the client's drop detection.
+
+  An empty $containers list matches every container; otherwise an entry matches
+    when its container name is in the list. The anonymous `/run` programs are
+    captured under the empty name; clients select them with the
+    $RUN-CONTAINER-SENTINEL placeholder, which is mapped back to "" here before
+    matching.
+
+  Lazily enables capture on the first call.
+  */
+  drain --cursor/int --containers/List=[] --max-hold/Duration=DEFAULT-HOLD -> Map:
+    enable
+    containers = containers.map: | name | name == RUN-CONTAINER-SENTINEL ? "" : name
+    if not has-match_ cursor containers:
+      exception := catch:
+        with-timeout max-hold:
+          signal_.wait: has-match_ cursor containers
+      if exception and exception != DEADLINE-EXCEEDED-ERROR: throw exception
+    return collect_ cursor containers
+
+  // Whether $entry is past $cursor and passes the $containers filter (an empty
+  // filter matches every container).
+  matches_ entry/LogEntry cursor/int containers/List -> bool:
+    return entry.seq > cursor and (containers.is-empty or containers.contains entry.container)
+
+  has-match_ cursor/int containers/List -> bool:
+    entries_.do: | entry/LogEntry |
+      if matches_ entry cursor containers: return true
+    return false
+
+  collect_ cursor/int containers/List -> Map:
+    list := []
+    bytes := 0
+    // The seq of the last entry we returned; stays at cursor when nothing matches.
+    last-included := cursor
+    entries_.do: | entry/LogEntry |
+      if matches_ entry cursor containers:
+        // Stop before exceeding the cap, but always return at least one entry so
+        // an oversized line can't stall the stream. Non-local return doubles as a
+        // break: resume the next drain from the last entry we returned.
+        if (not list.is-empty) and bytes + entry.size > MAX-DRAIN-BYTES:
+          return drain-result_ list last-included
+        list.add entry.to-list
+        bytes += entry.size
+        last-included = entry.seq
+    // Scanned the whole ring, so jump next past head, skipping any trailing
+    // non-matching entries (max guards a cursor already past head).
+    return drain-result_ list (max cursor head_)
+
+  drain-result_ entries/List next/int -> Map:
+    return {
+      "next": next,
+      "head": head_,
+      "oldest": oldest_,
+      "entries": entries,
+    }
+
+  /**
+  Applies a configuration $config decoded from the wire.
+
+  The map may contain "buffer_size" (int), "min_level" (a level name like
+    "INFO"), and "enabled" (bool). Missing fields leave the matching setting
+    unchanged. A shrunk "buffer_size" takes effect immediately by evicting
+    entries that no longer fit. "enabled": true calls $enable, "enabled": false
+    calls $disable. Returns whether capture is enabled afterwards.
+  */
+  apply-config config/Map -> bool:
+    buffer-size/int? := config.get "buffer_size"
+    if buffer-size != null: buffer-size_ = buffer-size
+    min-level/string? := config.get "min_level"
+    if min-level != null: min-level_ = parse-log-level min-level
+    evict_
+    enabled := config.get "enabled"
+    if enabled == true: enable
+    else if enabled == false: disable
+    return enabled_
+
+/** Parses a log level name (e.g. "INFO") into its numeric level. */
+parse-log-level name/string -> int:
+  if name == "TRACE": return log.TRACE-LEVEL
+  if name == "DEBUG": return log.DEBUG-LEVEL
+  if name == "INFO": return log.INFO-LEVEL
+  if name == "WARN": return log.WARN-LEVEL
+  if name == "ERROR": return log.ERROR-LEVEL
+  if name == "FATAL": return log.FATAL-LEVEL
+  throw "unknown log level: $name"

--- a/src/log/capture.toit
+++ b/src/log/capture.toit
@@ -1,0 +1,84 @@
+// Copyright (C) 2026 Toitware ApS. All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+import encoding.base64
+import system.services
+import system.api.print show PrintService
+import system.api.log show LogService
+import system.api.trace show TraceService
+
+import .buffer
+import .render
+
+/**
+The service provider that intercepts print/log/trace output.
+
+Each output kind has its own handler object, since the three services share the
+  same method index (0) and must not collide. The providers register at strictly
+  higher priority than any system default so that newly started containers bind
+  to them.
+
+Providers pass the intercepted entries to $LogBuffer. Entries also get printed
+  to UART, mimicking what default log and print handlers do.
+*/
+class CaptureProvider extends services.ServiceProvider:
+  static PRIORITY ::= services.ServiceProvider.PRIORITY-PREFERRED-STRONGLY
+
+  constructor buffer/LogBuffer:
+    super "toitlang.org/jaguar-capture" --major=1 --minor=0
+    provides PrintService.SELECTOR --handler=(PrintHandler_ buffer) --priority=PRIORITY
+    provides LogService.SELECTOR --handler=(LogHandler_ buffer) --priority=PRIORITY
+    provides TraceService.SELECTOR --handler=(TraceHandler_ buffer) --priority=PRIORITY
+
+class PrintHandler_ implements services.ServiceHandler:
+  buffer_/LogBuffer
+  constructor .buffer_:
+
+  handle index/int arguments/any --gid/int --client/int -> any:
+    if index == PrintService.PRINT-INDEX:
+      message/string := arguments
+      // Preserve the serial console (even while capture is disabled).
+      write-on-stdout_ message true
+      buffer_.append-print message --gid=gid
+      return null
+    unreachable
+
+class LogHandler_ implements services.ServiceHandler:
+  buffer_/LogBuffer
+  constructor .buffer_:
+
+  handle index/int arguments/any --gid/int --client/int -> any:
+    if index == LogService.LOG-INDEX:
+      level/int := arguments[0]
+      message/string := arguments[1]
+      names/List? := arguments[2]
+      keys/List? := arguments[3]
+      values/List? := arguments[4]
+      text := render-log level message names keys values
+      // Preserve the serial console (all levels), then capture at the floor.
+      // This mirrors the SDK default path: render as StandardLogService_ does,
+      // then write to stdout with a trailing newline (as print's fallback does).
+      write-on-stdout_ text true
+      buffer_.append-log level text --gid=gid
+      return null
+    unreachable
+
+class TraceHandler_ implements services.ServiceHandler:
+  buffer_/LogBuffer
+  constructor .buffer_:
+
+  handle index/int arguments/any --gid/int --client/int -> any:
+    if index == TraceService.HANDLE-TRACE-INDEX:
+      message/ByteArray := arguments
+      buffer_.append-trace "jag decode $(base64.encode message)" --gid=gid
+      // Return the message unhandled so the system still prints it to the UART.
+      return message
+    unreachable
+
+/**
+Writes $message directly to the UART/stdout primitive, bypassing the print
+  service so that our own provider does not recurse.
+*/
+write-on-stdout_ message/string add-newline/bool -> none:
+  #primitive.core.write-on-stdout

--- a/src/log/entry.toit
+++ b/src/log/entry.toit
@@ -1,0 +1,49 @@
+// Copyright (C) 2026 Toitware ApS. All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+// Entry types stored as metadata so the host can filter the captured set.
+TYPE-PRINT ::= "print"
+TYPE-LOG   ::= "log"
+TYPE-TRACE ::= "trace"
+// A synthetic entry marking that the producing container stopped; its text is
+// the exit code. Lets a container-filtered `run -m` know when the program
+// finished.
+TYPE-EXIT  ::= "exit"
+
+// Approximate overhead (in bytes) per $LogEntry, used to estimate encoded size
+// in ubjson.
+ENTRY-OVERHEAD_ ::= 16
+
+/**
+A single captured print, log or trace entry.
+
+The $text is pre-rendered for display. The $type and $level are kept as
+  metadata so the host can do its own filtering.
+
+The $container is the name jaguar started the producing container under: empty
+  for an anonymous `/run` program, the install name for an `/install`-ed
+  container, and "?" for a gid jaguar did not start (e.g. a system container).
+*/
+class LogEntry:
+  seq/int
+  container/string
+  type/string
+  level/int?
+  text/string
+  // Approximate encoded byte cost of this entry, summed into the ring buffer
+  // budget for eviction.
+  size/int
+
+  constructor .seq .container .type .level .text:
+    size = ENTRY-OVERHEAD_ + container.size + type.size + text.size
+
+  /**
+  Serializes the entry as a fixed-order array [seq, container, type, level,
+  text].
+
+  We use an array instead of a map to avoid repeating field names on every
+    entry. This roughly halves the encoded list of entries sent to host.
+  */
+  to-list -> List:
+    return [seq, container, type, level, text]

--- a/src/log/render.toit
+++ b/src/log/render.toit
@@ -1,0 +1,31 @@
+// Copyright (C) 2026 Toitware ApS. All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+import io
+import log
+
+/**
+Renders a log record the same way the SDK's StandardLogService_ does, so that
+  the captured text matches the serial output.
+*/
+render-log level/int message/string names/List? keys/List? values/List? -> string:
+  buffer := io.Buffer
+  if names and names.size > 0:
+    buffer.write "["
+    names.size.repeat:
+      if it > 0: buffer.write "."
+      buffer.write names[it]
+    buffer.write "] "
+  buffer.write (log.level-name level)
+  buffer.write ": "
+  buffer.write message
+  if keys and keys.size > 0:
+    buffer.write " {"
+    keys.size.repeat:
+      if it > 0: buffer.write ", "
+      buffer.write keys[it]
+      buffer.write ": "
+      buffer.write values[it]
+    buffer.write "}"
+  return buffer.to-string

--- a/src/network.toit
+++ b/src/network.toit
@@ -4,6 +4,7 @@
 
 import encoding.json
 import encoding.ubjson
+import encoding.url
 import http
 import log
 import monitor
@@ -31,6 +32,7 @@ HEADER-CONTAINER-TIMEOUT  ::= "X-Jaguar-Container-Timeout"
 HEADER-CONTAINER-INTERVAL ::= "X-Jaguar-Container-Interval"
 HEADER-CRC32              ::= "X-Jaguar-CRC32"
 HEADER-DISABLE-UDP        ::= "X-Jaguar-Disable-UDP"
+HEADER-LOG-CONFIG         ::= "X-Jaguar-Log-Config"
 
 // Assets for the mini-webpage that the device serves up on $HTTP_PORT.
 CHIP-IMAGE ::= "https://toitlang.github.io/jaguar/device-files/chip.svg"
@@ -164,7 +166,10 @@ class EndpointHttp implements Endpoint:
       device-id := "$device.id"
       device-id-header := headers.single HEADER-DEVICE-ID
       sdk-version-header := headers.single HEADER-SDK-VERSION
-      path := request.path
+      // Use the resource (the path without any query string) for routing, so
+      // that e.g. '/log?cursor=5' still matches '/log'.
+      query := url.QueryString.parse request.path
+      path := query.resource
 
       // Handle identification requests before validation, as the caller doesn't know that information yet.
       if path == "/identify" and request.method == http.GET:
@@ -203,6 +208,17 @@ class EndpointHttp implements Endpoint:
           firmware-is-upgrade-pending = true
           socket.close
 
+      // Handle draining the log ring buffer.
+      else if path == "/log" and request.method == http.GET:
+        request-mutex.do:
+          respond writer headers (drain-log query)
+
+      // Handle configuring the log ring buffer.
+      else if path == "/log/configure" and request.method == http.PUT:
+        request-mutex.do:
+          log-buffer_.apply-config (json.decode request.body.read-all)
+          respond-ok writer headers
+
       // Validate SDK version before attempting to install containers or run code.
       else if sdk-version-header != system.vm-sdk-version:
         logger.info "denied request, header: '$HEADER-SDK-VERSION' was '$sdk-version-header' not '$system.vm-sdk-version'"
@@ -210,6 +226,17 @@ class EndpointHttp implements Endpoint:
 
       // Handle installing containers and code running.
       else if (path == "/install" or path == "/run") and request.method == "PUT":
+        // The optional log-config header carries a JSON object configuring log
+        // capture for this run (same structure as /log/configure), e.g.
+        // {"enabled": true, "buffer_size": 4096, "min_level": "INFO"}. Missing
+        // fields leave the matching setting unchanged. Applying it before the
+        // container starts lets it bind to our providers from its first print.
+        log-config-header := headers.single HEADER-LOG-CONFIG
+        if log-config-header:
+          log-config := json.parse log-config-header
+          // Configure capture before starting, so the container binds to our
+          // providers from its first print.
+          log-buffer_.apply-config log-config
         image/Uuid? := null
         defines/Map? := null
         container-name/string? := null
@@ -236,6 +263,24 @@ class EndpointHttp implements Endpoint:
     if header := headers.single HEADER-CONTAINER-INTERVAL:
       defines[JAG-INTERVAL] = header
     return defines
+
+  /**
+  Parses the cursor and container filter out of a `GET /log` query and drains
+  the ring buffer accordingly.
+  */
+  drain-log query/url.QueryString -> Map:
+    parameters := query.parameters
+    cursor := int.parse (parameters.get "cursor" --if-absent=: "0")
+    // Repeat the "containers" parameter to filter to several names at once.
+    // Absent (empty list) means no filter. Anonymous `/run` output is under the
+    // empty name; clients pass the "_run_" sentinel for it, which
+    // LogBuffer.drain maps back to "". The url parser yields a single value as a
+    // string and repeats as a List.
+    containers-parameter := parameters.get "containers"
+    containers/List := containers-parameter == null
+        ? []
+        : (containers-parameter is List ? containers-parameter : [containers-parameter])
+    return log-buffer_.drain --cursor=cursor --containers=containers
 
   /**
   Writes $result as the response body, picking the encoding from the request's

--- a/src/network.toit
+++ b/src/network.toit
@@ -2,6 +2,7 @@
 // Use of this source code is governed by an MIT-style license that can be
 // found in the LICENSE file.
 
+import encoding.json
 import encoding.ubjson
 import http
 import log
@@ -18,7 +19,9 @@ import .jaguar
 HTTP-PORT        ::= 9000
 IDENTIFY-PORT    ::= 1990
 IDENTIFY-ADDRESS ::= net.IpAddress.parse "255.255.255.255"
-STATUS-OK-JSON   ::= """{ "status": "OK" }"""
+
+CONTENT-TYPE-JSON   ::= "application/json"
+CONTENT-TYPE-UBJSON ::= "application/ubjson"
 
 HEADER-DEVICE-ID          ::= "X-Jaguar-Device-ID"
 HEADER-SDK-VERSION        ::= "X-Jaguar-SDK-Version"
@@ -27,7 +30,7 @@ HEADER-CONTAINER-NAME     ::= "X-Jaguar-Container-Name"
 HEADER-CONTAINER-TIMEOUT  ::= "X-Jaguar-Container-Timeout"
 HEADER-CONTAINER-INTERVAL ::= "X-Jaguar-Container-Interval"
 HEADER-CRC32              ::= "X-Jaguar-CRC32"
-HEADER-DISABLE-UDP       ::= "X-Jaguar-Disable-UDP"
+HEADER-DISABLE-UDP        ::= "X-Jaguar-Disable-UDP"
 
 // Assets for the mini-webpage that the device serves up on $HTTP_PORT.
 CHIP-IMAGE ::= "https://toitlang.github.io/jaguar/device-files/chip.svg"
@@ -78,23 +81,21 @@ class EndpointHttp implements Endpoint:
       if socket: socket.close
       network.close
 
-  identity-payload device/Device address/string -> ByteArray:
-    identity := """
-      { "method": "jaguar.identify",
-        "payload": {
-          "name": "$device.name",
-          "id": "$device.id",
-          "chip": "$device.chip",
-          "sdkVersion": "$system.vm-sdk-version",
-          "address": "$address",
-          "wordSize": $system.BYTES-PER-WORD
-        }
-      }
-    """
-    return identity.to-byte-array
+  identity-map device/Device address/string -> Map:
+    return {
+      "method": "jaguar.identify",
+      "payload": {
+        "name": device.name,
+        "id": "$device.id",
+        "chip": device.chip,
+        "sdkVersion": system.vm-sdk-version,
+        "address": address,
+        "wordSize": system.BYTES-PER-WORD,
+      },
+    }
 
   broadcast-identity network/net.Interface device/Device address/string -> none:
-    payload ::= identity-payload device address
+    payload ::= json.encode (identity-map device address)
     datagram ::= udp.Datagram
         payload
         net.SocketAddress IDENTIFY-ADDRESS IDENTIFY-PORT
@@ -167,10 +168,7 @@ class EndpointHttp implements Endpoint:
 
       // Handle identification requests before validation, as the caller doesn't know that information yet.
       if path == "/identify" and request.method == http.GET:
-        writer.headers.set "Content-Type" "application/json"
-        result := identity-payload device address
-        writer.headers.set "Content-Length" result.size.stringify
-        writer.out.write result
+        respond writer headers (identity-map device address)
 
       else if path == "/" or path.ends-with ".html" or path.ends-with ".css" or path.ends-with ".ico":
         handle-browser-request device.name request writer
@@ -182,27 +180,24 @@ class EndpointHttp implements Endpoint:
 
       // Handle pings.
       else if path == "/ping" and request.method == http.GET:
-        respond-ok writer
+        respond-ok writer headers
 
       // Handle listing containers.
       else if path == "/list" and request.method == http.GET:
-        result := ubjson.encode registry_.entries
-        writer.headers.set "Content-Type" "application/ubjson"
-        writer.headers.set "Content-Length" result.size.stringify
-        writer.out.write result
+        respond writer headers registry_.entries --default-content-type=CONTENT-TYPE-UBJSON
 
       // Handle uninstalling containers.
       else if path == "/uninstall" and request.method == http.PUT:
         request-mutex.do:
           container-name ::= headers.single HEADER-CONTAINER-NAME
           uninstall-image container-name
-          respond-ok writer
+          respond-ok writer headers
 
       // Handle firmware updates.
       else if path == "/firmware" and request.method == http.PUT:
         request-mutex.do:
           install-firmware request.content-length request.body
-          respond-ok writer
+          respond-ok writer headers
           // Mark the firmware as having a pending upgrade and close
           // the server socket to force the HTTP server loop to stop.
           firmware-is-upgrade-pending = true
@@ -225,7 +220,7 @@ class EndpointHttp implements Endpoint:
           crc32 := int.parse (headers.single HEADER-CRC32)
           defines = extract-defines headers
           image = flash-image request.content-length request.body container-name defines --crc32=crc32
-          respond-ok writer
+          respond-ok writer headers
         run-message := path == "/install" ? "installed and started" : "started"
         start-image image run-message container-name defines
 
@@ -242,10 +237,29 @@ class EndpointHttp implements Endpoint:
       defines[JAG-INTERVAL] = header
     return defines
 
-  respond-ok writer/http.ResponseWriter -> none:
-    writer.headers.set "Content-Type" "application/json"
-    writer.headers.set "Content-Length" STATUS-OK-JSON.size.stringify
-    writer.out.write STATUS-OK-JSON
+  /**
+  Writes $result as the response body, picking the encoding from the request's
+    `Accept` header, falling back to $default-content-type argument.
+
+  This allows using either easy to read and debug JSON or more compact ubjson
+  encoding.
+  */
+  respond writer/http.ResponseWriter headers/http.Headers result/any
+      --default-content-type/string=CONTENT-TYPE-JSON -> none:
+    accept := headers.single "Accept"
+    content-type/string := default-content-type
+    if accept:
+      if accept.contains CONTENT-TYPE-UBJSON: content-type = CONTENT-TYPE-UBJSON
+      else if accept.contains CONTENT-TYPE-JSON: content-type = CONTENT-TYPE-JSON
+    encoded/ByteArray := content-type == CONTENT-TYPE-UBJSON
+        ? ubjson.encode result
+        : json.encode result
+    writer.headers.set "Content-Type" content-type
+    writer.headers.set "Content-Length" encoded.size.stringify
+    writer.out.write encoded
+
+  respond-ok writer/http.ResponseWriter headers/http.Headers -> none:
+    respond writer headers { "status": "OK" }
 
   name -> string:
     return "HTTP"

--- a/tests/device/log-buffer-test.toit
+++ b/tests/device/log-buffer-test.toit
@@ -1,0 +1,368 @@
+// Copyright (C) 2026 Toitware ApS. All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+import expect show *
+import log
+import monitor
+
+import ..src.log.buffer show LogBuffer RUN-CONTAINER-SENTINEL MAX-DRAIN-BYTES
+import ..src.log.entry
+
+// Field positions within a drained entry array (see LogEntry.to-list).
+ENTRY-IDX-SEQ       ::= 0
+ENTRY-IDX-CONTAINER ::= 1
+ENTRY-IDX-TYPE      ::= 2
+ENTRY-IDX-LEVEL     ::= 3
+ENTRY-IDX-TEXT      ::= 4
+
+main:
+  test-empty
+  test-append-noop-when-disabled
+  test-append
+  test-min-level-floor
+  test-cursor-filter
+  test-container-filter
+  test-container-registry
+  test-eviction
+  test-eviction-keeps-newest
+  test-configure-shrink
+  test-has-match
+  test-drain
+  test-collect-next
+  test-collect-cap
+  test-collect-cap-oversized
+
+// A fresh ring: nothing captured, head at 0 and oldest one past it (so a client
+// polling from cursor 0 sees no drops).
+test-empty:
+  buffer := LogBuffer
+  expect-equals 0 buffer.head_
+  expect-equals 1 buffer.oldest_
+  result := buffer.collect_ 0 []
+  expect-equals 0 result["head"]
+  expect-equals 1 result["oldest"]
+  expect-equals 0 result["entries"].size
+
+// Appends are only recorded when capture is enabled - otherwise nothing is
+// draining the ring and it should not grow. Covers all four append- entry points.
+test-append-noop-when-disabled:
+  buffer := LogBuffer  // Not enabled.
+  buffer.append-print "p" --gid=1
+  buffer.append-log log.ERROR-LEVEL "l" --gid=1
+  buffer.append-trace "jag decode T" --gid=1
+  buffer.append-exit --gid=1 --code=0
+  expect-equals 0 buffer.head_
+  expect-equals 0 (buffer.collect_ 0 [])["entries"].size
+
+// Appends assign monotonic 1-based seqs and carry the right metadata.
+test-append:
+  buffer := LogBuffer
+  buffer.enabled_ = true
+  buffer.register-container --gid=1 --name="one"
+  buffer.register-container --gid=2 --name=""
+  buffer.register-container --gid=3 --name="three"
+  buffer.append-print "a" --gid=1
+  buffer.append-log log.WARN-LEVEL "WARN: b" --gid=2
+  buffer.append-trace "jag decode XYZ" --gid=3
+
+  expect-equals 3 buffer.head_
+  expect-equals 1 buffer.oldest_
+
+  entries := (buffer.collect_ 0 [])["entries"]
+  expect-equals 3 entries.size
+  expect-structural-equals
+    [1, "one", TYPE-PRINT, null, "a"]
+    entries[0]
+  expect-structural-equals
+    [2, "", TYPE-LOG, log.WARN-LEVEL, "WARN: b"]
+    entries[1]
+  expect-structural-equals
+    [3, "three", TYPE-TRACE, null, "jag decode XYZ"]
+    entries[2]
+
+// Log entries below the floor never enter the ring and never consume a seq;
+// prints have no level and are always captured.
+test-min-level-floor:
+  buffer := LogBuffer  // Default floor is INFO.
+  buffer.enabled_ = true
+  buffer.append-log log.DEBUG-LEVEL "dropped" --gid=1
+  buffer.append-log log.INFO-LEVEL "kept-info" --gid=1
+  buffer.append-log log.ERROR-LEVEL "kept-error" --gid=1
+  buffer.append-print "kept-print" --gid=1
+
+  // Only three of the four made it in, and seqs stay contiguous.
+  expect-equals 3 buffer.head_
+  entries := (buffer.collect_ 0 [])["entries"]
+  expect-equals 3 entries.size
+  expect-equals "kept-info" entries[0][ENTRY-IDX-TEXT]
+  expect-equals "kept-error" entries[1][ENTRY-IDX-TEXT]
+  expect-equals "kept-print" entries[2][ENTRY-IDX-TEXT]
+
+// Draining returns only entries with seq greater than the cursor.
+test-cursor-filter:
+  buffer := LogBuffer
+  buffer.enabled_ = true
+  3.repeat: buffer.append-print "m$it" --gid=1
+
+  from-start := (buffer.collect_ 0 [])["entries"]
+  expect-equals 3 from-start.size
+
+  tail := (buffer.collect_ 1 [])["entries"]
+  expect-equals 2 tail.size
+  expect-equals 2 tail[0][ENTRY-IDX-SEQ]
+  expect-equals 3 tail[1][ENTRY-IDX-SEQ]
+
+  expect-equals 0 (buffer.collect_ 3 [])["entries"].size
+
+// Draining can be narrowed to a set of producing container names. The empty
+// name (anonymous `/run` programs) is a value like any other, and an empty list
+// means no filter.
+test-container-filter:
+  buffer := LogBuffer
+  buffer.enabled_ = true
+  buffer.register-container --gid=1 --name="app"
+  buffer.register-container --gid=2 --name=null  // Anonymous `/run` -> "".
+  buffer.append-print "x" --gid=1
+  buffer.append-print "y" --gid=2
+  buffer.append-print "z" --gid=1
+
+  all := (buffer.collect_ 0 [])["entries"]  // Empty list: no filter.
+  expect-equals 3 all.size
+
+  mine := (buffer.collect_ 0 ["app"])["entries"]
+  expect-equals 2 mine.size
+  expect-equals "x" mine[0][ENTRY-IDX-TEXT]
+  expect-equals "z" mine[1][ENTRY-IDX-TEXT]
+
+  anonymous := (buffer.collect_ 0 [""])["entries"]
+  expect-equals 1 anonymous.size
+  expect-equals "y" anonymous[0][ENTRY-IDX-TEXT]
+
+  // Several names at once, including the anonymous empty name.
+  both := (buffer.collect_ 0 ["app", ""])["entries"]
+  expect-equals 3 both.size
+
+  expect-equals 0 (buffer.collect_ 0 ["other"])["entries"].size
+
+// The gid->name registry resolves a gid to its registered name, falls back to
+// "?" for an unknown gid, and stores a null name as the empty string.
+test-container-registry:
+  buffer := LogBuffer
+  expect-equals "?" (buffer.name-for-gid_ 1)
+
+  buffer.register-container --gid=1 --name="app"
+  buffer.register-container --gid=2 --name=null  // Anonymous `/run`.
+  expect-equals "app" (buffer.name-for-gid_ 1)
+  expect-equals "" (buffer.name-for-gid_ 2)
+
+  buffer.unregister-container --gid=1
+  expect-equals "?" (buffer.name-for-gid_ 1)
+  expect-equals "" (buffer.name-for-gid_ 2)
+
+// The ring evicts whole oldest entries once the payload exceeds the budget,
+// while head keeps climbing and oldest tracks the lowest surviving seq.
+test-eviction:
+  buffer := LogBuffer
+  buffer.enabled_ = true
+  // Each entry's charged size now counts every field plus a fixed overhead, so
+  // derive the budget from a real entry instead of hard-coding bytes. All three
+  // entries are equal size (same container, type and 4-char text).
+  buffer.append-print "aaaa" --gid=1  // seq 1
+  entry-size := buffer.total-bytes_
+  buffer.apply-config {"buffer_size": 2 * entry-size}  // holds exactly two
+  buffer.append-print "bbbb" --gid=1  // seq 2, two entries fit
+  buffer.append-print "cccc" --gid=1  // seq 3 -> evict seq 1 -> two left
+
+  expect-equals 3 buffer.head_
+  expect-equals 2 buffer.oldest_
+  entries := (buffer.collect_ 0 [])["entries"]
+  expect-equals 2 entries.size
+  expect-equals 2 entries[0][ENTRY-IDX-SEQ]
+  expect-equals 3 entries[1][ENTRY-IDX-SEQ]
+
+// The most recently appended entry is always retained, even when it alone
+// exceeds the budget.
+test-eviction-keeps-newest:
+  buffer := LogBuffer
+  buffer.enabled_ = true
+  buffer.apply-config {"buffer_size": 1}
+  buffer.append-print "aaaaaaaa" --gid=1  // 8 bytes > budget, but it is the newest
+  expect-equals 1 (buffer.collect_ 0 [])["entries"].size
+
+  buffer.append-print "bbbbbbbb" --gid=1
+  entries := (buffer.collect_ 0 [])["entries"]
+  expect-equals 1 entries.size
+  expect-equals "bbbbbbbb" entries[0][ENTRY-IDX-TEXT]
+  expect-equals 2 buffer.head_
+  expect-equals 2 buffer.oldest_
+
+// Shrinking the buffer evicts immediately to fit the new budget.
+test-configure-shrink:
+  buffer := LogBuffer
+  buffer.enabled_ = true
+  buffer.apply-config {"buffer_size": 1_000_000}  // effectively unbounded
+  4.repeat: buffer.append-print "1234567890" --gid=1  // four equal entries, all fit
+  expect-equals 4 (buffer.collect_ 0 [])["entries"].size
+
+  entry-size := buffer.total-bytes_ / 4
+  buffer.apply-config {"buffer_size": 2 * entry-size}  // keep only the last two
+  entries := (buffer.collect_ 0 [])["entries"]
+  expect-equals 2 entries.size
+  expect-equals 3 entries[0][ENTRY-IDX-SEQ]
+  expect-equals 4 entries[1][ENTRY-IDX-SEQ]
+
+// The long-poll wake predicate honors both the cursor and the container filter.
+test-has-match:
+  buffer := LogBuffer
+  buffer.enabled_ = true
+  buffer.register-container --gid=1 --name="app"
+  buffer.append-print "a" --gid=1
+  expect (buffer.has-match_ 0 [])
+  expect-not (buffer.has-match_ 1 [])  // cursor at head: nothing newer
+  expect (buffer.has-match_ 0 ["app"])
+  expect-not (buffer.has-match_ 0 ["other"])
+
+test-drain:
+  buffer := LogBuffer
+  buffer.enabled_ = true
+  buffer.register-container --gid=1 --name="app"
+  buffer.register-container --gid=2 --name=null  // Anonymous `/run` -> "".
+  buffer.append-print "one" --gid=1
+  // When a matching entry already exists, drain returns it without blocking.
+  // The timeout guards against an accidental long-poll: it would fire only if
+  // drain blocked on the empty-ring path.
+  result := with-timeout (Duration --ms=100): buffer.drain --cursor=0
+  entries := result["entries"]
+  expect-equals 1 entries.size
+  expect-equals "one" entries[0][ENTRY-IDX-TEXT]
+  cursor := result["head"]
+  expect-equals 1 cursor
+
+  // With no new entries, drain long-polls and wakes as soon as one is appended
+  // from another task. It must stay blocked until the append and then return
+  // the new entry promptly.
+  result = wait-for-drain-to-block-then-send
+    buffer
+    --cursor=cursor
+    --run-when-blocked=(: it.append-print "two" --gid=2 )
+  entries = result["entries"]
+  expect-equals 1 entries.size
+  expect-equals "two" entries[0][ENTRY-IDX-TEXT]
+  cursor = result["head"]
+  expect-equals 2 cursor
+
+  // Add another entry from the "app" container and validate that waiting on
+  // anonymous container still blocks, but returns when we add an entry with
+  // matching container.
+  buffer.append-print "three" --gid=1
+
+  result = wait-for-drain-to-block-then-send
+    buffer
+    --cursor=cursor
+    --containers=[RUN-CONTAINER-SENTINEL]
+    --run-when-blocked=(: it.append-print "four" --gid=2 )
+  entries = result["entries"]
+  expect-equals 1 entries.size
+  expect-equals "four" entries[0][ENTRY-IDX-TEXT]
+  cursor = result["head"]
+  expect-equals 4 cursor
+
+// When the whole (matching) ring fits in one drain, "next" jumps to head - even
+// past trailing entries that the container filter excluded - so the next poll
+// long-polls for new output instead of re-scanning them.
+test-collect-next:
+  buffer := LogBuffer
+  buffer.enabled_ = true
+  buffer.register-container --gid=1 --name="app"
+  buffer.register-container --gid=2 --name="other"
+  buffer.append-print "a" --gid=1  // seq 1, app
+  buffer.append-print "b" --gid=1  // seq 2, app
+  buffer.append-print "c" --gid=2  // seq 3, other (trailing, excluded by the app filter)
+
+  result := buffer.collect_ 0 ["app"]
+  expect-equals 2 result["entries"].size
+  expect-equals 3 result["head"]
+  expect-equals 3 result["next"]  // advanced to head, past the excluded seq 3
+
+  // Draining again from next is caught up: nothing new, next stays at head.
+  caught-up := buffer.collect_ result["next"] ["app"]
+  expect-equals 0 caught-up["entries"].size
+  expect-equals 3 caught-up["next"]
+
+// A drain returns at most MAX-DRAIN-BYTES of entries; "next" is then the last
+// returned seq (below head) and a client pages through the rest. Every entry is
+// delivered exactly once across the pages.
+test-collect-cap:
+  buffer := LogBuffer
+  buffer.enabled_ = true
+  buffer.apply-config {"buffer_size": 1_000_000}  // no eviction; build a big backlog
+  count := 50
+  count.repeat: buffer.append-print ("x" * 100) --gid=1  // ~122 bytes each, >> the cap total
+
+  first := buffer.collect_ 0 []
+  entries := first["entries"]
+  // Capped: only a fraction of the backlog, sized near the cap (~8 of ~122 bytes).
+  expect entries.size < count
+  expect entries.size > 0
+  expect entries.size <= 12
+  expect-equals count first["head"]
+  // next is the last returned seq, short of head.
+  expect-equals entries[entries.size - 1][ENTRY-IDX-SEQ] first["next"]
+  expect first["next"] < first["head"]
+
+  // Page through the remaining backlog with next; tally every delivered entry.
+  cursor := first["next"]
+  total := entries.size
+  seen-last := entries[entries.size - 1][ENTRY-IDX-SEQ]
+  while cursor < first["head"]:
+    page := buffer.collect_ cursor []
+    page-entries := page["entries"]
+    expect page-entries.size > 0
+    expect-equals (seen-last + 1) page-entries[0][ENTRY-IDX-SEQ]  // continues right after the last seq
+    total += page-entries.size
+    seen-last = page-entries[page-entries.size - 1][ENTRY-IDX-SEQ]
+    cursor = page["next"]
+  expect-equals count total  // each entry delivered exactly once
+
+// A single entry larger than the cap is still returned on its own, so an
+// oversized line never stalls the stream.
+test-collect-cap-oversized:
+  buffer := LogBuffer
+  buffer.enabled_ = true
+  buffer.apply-config {"buffer_size": 1_000_000}
+  big := "y" * (MAX-DRAIN-BYTES + 500)
+  buffer.append-print big --gid=1     // seq 1, alone exceeds the cap
+  buffer.append-print "after" --gid=1  // seq 2
+
+  first := buffer.collect_ 0 []
+  expect-equals 1 first["entries"].size
+  expect-equals big first["entries"][0][ENTRY-IDX-TEXT]
+  expect-equals 1 first["next"]
+
+  second := buffer.collect_ first["next"] []
+  expect-equals 1 second["entries"].size
+  expect-equals "after" second["entries"][0][ENTRY-IDX-TEXT]
+
+/**
+Checks that drain with the given $cursor and $containers will block,
+  then runs $run-when-blocked, expects drain to finish and returns
+  the resulting value.
+*/
+wait-for-drain-to-block-then-send -> Map
+    buffer/LogBuffer
+    --cursor/int
+    --containers/List=[]
+    [--run-when-blocked]:
+  latch := monitor.Latch
+  returned := false
+  task::
+    result := buffer.drain --cursor=cursor --containers=containers
+    returned = true
+    latch.set result
+  sleep --ms=10
+  expect-not returned
+  // Appending a matching entry should wake the blocked drain.
+  run-when-blocked.call buffer
+  result := with-timeout (Duration --ms=100): latch.get
+  return result

--- a/tests/device/log-render-test.toit
+++ b/tests/device/log-render-test.toit
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 Toitware ApS. All rights reserved.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+import expect show *
+import log
+
+import ..src.log.render as render
+
+main:
+  test-render-log
+
+// Rendering matches the SDK's StandardLogService_ output, so the captured text
+// is identical to what shows up on the serial console: an optional `[a.b]` name
+// prefix, the level name, the message, and an optional `{k: v}` tag suffix.
+test-render-log:
+  expect-equals "INFO: hello"
+      render.render-log log.INFO-LEVEL "hello" null null null
+  expect-equals "[a.b] WARN: msg"
+      render.render-log log.WARN-LEVEL "msg" ["a", "b"] null null
+  expect-equals "[a] INFO: m {k: v}"
+      render.render-log log.INFO-LEVEL "m" ["a"] ["k"] ["v"]


### PR DESCRIPTION
This adds device-side print/log/trace capture and buffering, and CLI-side support for streaming the logs with `jag run -m` or `jag monitor network`. Fixes #660.

## Device-side changes

- Add `src/log/*.toit` - log ring buffer + service providers for capturing print/log/trace messages.
- Wire them up to `jaguar.toit` and `network.toit`.
- New `/log` endpoint that returns any new log data or waits up to 500ms as a long-poll mechanism. The timeout is short because the HTTP server handles one request at a time, so blocking on the poll stalls other actions. The response is limited to 1KB of logs (since encoding and sending blows it up ~3x, and we don't want to run out of heap).
- New `/log/configure` endpoint that allows setting buffer size (defaults to 4096 bytes) and minimum log level (defaults to INFO).
- With log capture enabled, messages are still printed to UART to preserve existing behavior.
- Log capture and buffering are opt-in. There should be no runtime impact when capture is not enabled.
- Small refactor to support responding in JSON or UBJSON, depending on the optional `Accept` request header, defaulting to previous formats if not specified.

## CLI changes

- `jag run` gains `-m/--monitor` to watch program output over the network via `/log`. This automatically filters the log entries to those produced by the anonymous container.
- Alternatively, `jag run --monitor-port <port>` reads the run's output from a serial port instead of the network (implies `-m`; shares code with `monitor.go`).
- `jag monitor` is split into `jag monitor uart` and `jag monitor network`; bare `jag monitor` falls back to UART to keep existing behavior.
- `jag monitor network` polls `/log` for current and future log messages, and can configure which container(s) to watch.

## Open Questions

It would be nice to have the ability to start logging at boot, if so configured.
- Usage example: something malfunctions with the device, and I want to peek at the latest logs that have been kept in the ring buffer.
- It looks like jaguar is started the same way as other at-boot containers. We would need jaguar to start before other containers, so it can install the log/print/trace providers before the lookup failure gets cached. Not sure how to best do this without adding some kind of priority property to the container record and having the boot process obey that.
- AFAICT, there isn't any mechanism to do container name<->gid lookups. So jaguar (or host) wouldn't be able to associate log message "gid"s to container names.

It would be nice if we could enable logging for currently running containers without having to restart them.
  - Currently log/print/trace does a single lookup for the providers and caches the failure.
  - How heavy would it be to have it watch on service discovery notifications in a background task and update the cached service client? Alternatively, is there some more lightweight way for jaguar to signal all containers to retry looking up the log/print/trace service providers?

Neither of these are blocking for this PR.