### PR TITLE
Fix ESP32-S2 flashing broken by the chip-type probe

### DIFF
--- a/cmd/jag/commands/firmware_flash.go
+++ b/cmd/jag/commands/firmware_flash.go
@@ -65,10 +65,9 @@ func withFirmware(cmd *cobra.Command, args []string, probeChip probeChip, device
 			// Run the esptool to probe the chip type.
 			probedChip, err := probeChip(ctx, sdk)
 			if err != nil {
-				return fmt.Errorf("failed to probe chip type: %w", err)
-			} else {
-				fmt.Printf("Probed chip type: %s\n", probedChip)
+				return err
 			}
+			fmt.Printf("Probed chip type: %s\n", probedChip)
 			chip = probedChip
 		} else {
 			chip = ""

--- a/cmd/jag/commands/flash.go
+++ b/cmd/jag/commands/flash.go
@@ -47,14 +47,22 @@ func FlashCmd() *cobra.Command {
 
 			probeChipType := func(ctx context.Context, sdk *SDK) (string, error) {
 				result, err := ProbeChipType(ctx, port, sdk)
-				if err == nil {
-					if exists, err := PortExists(port); err != nil || !exists {
-						// Some boards leave flash mode and require manual intervention after
-						// ever interaction. Tell the user how to work around this.
-						fmt.Println("Note: Your board disappeared after probing the chip type.\n" +
-							"This can happen on some boards that require manual intervention to enter flash mode.\n" +
-							"Use '--chip=" + result + "' to avoid this probe step in the future.")
-					}
+				if err != nil {
+					return result, err
+				}
+				// Probing the chip type talks to the chip over serial, which resets
+				// it. Boards that use the ESP32's integrated USB peripheral (for
+				// example the ESP32-S2) are taken out of their manually-entered
+				// download mode by this, and their serial port disappears. There is
+				// no reliable way to probe without disturbing such boards, so detect
+				// the situation and tell the user how to skip the probe. We already
+				// have the chip type from the probe, so we can name the exact flag.
+				if exists, existsErr := PortExists(port); existsErr == nil && !exists {
+					return "", fmt.Errorf(
+						"the board left download mode after probing its chip type.\n"+
+							"This happens on boards that use the ESP32's integrated USB peripheral (for example\n"+
+							"the ESP32-S2) and must be put into download mode manually. Re-enter download mode and\n"+
+							"run again with '--chip=%s' to skip the chip-type probe.", result)
 				}
 				return result, err
 			}
@@ -78,16 +86,19 @@ func FlashCmd() *cobra.Command {
 				// escaping rules for COM ports over 10 (COM10, COM11),
 				// which we don't want to deal with.
 				if os.PathSeparator != '\\' && !shouldSkipPortCheck {
-					// Use golang to check the port can be opened for writing first.
-					// This is to avoid the error message from esptool.py, which is
-					// confusing to users in the common case where the port is owned
+					// Check the port is writable first, to avoid the confusing error
+					// message from esptool in the common case where the port is owned
 					// by the dialout or uucp group.
-					file, err := os.OpenFile(port, os.O_WRONLY, 0)
-					if err != nil {
+					//
+					// We deliberately do NOT open the port to check this: opening (and
+					// closing) a serial port toggles the DTR/RTS lines, which resets
+					// boards that use the ESP32's integrated USB peripheral (for example
+					// the ESP32-S2) and takes them out of the manually-entered download
+					// mode before we get a chance to flash. checkPortWritable uses
+					// access(2) instead, which never opens the port.
+					if err := checkPortWritable(port); err != nil {
 						return err
 					}
-					// Close the file again:
-					file.Close()
 				}
 
 				fmt.Printf("Flashing device over serial on port '%s' ...\n", port)

--- a/cmd/jag/commands/port_writable_unix.go
+++ b/cmd/jag/commands/port_writable_unix.go
@@ -1,0 +1,21 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+//go:build !windows
+
+package commands
+
+import "syscall"
+
+// checkPortWritable reports whether the given port can be opened for writing,
+// without actually opening it.
+//
+// Opening (and closing) a serial port toggles the DTR/RTS modem-control lines,
+// which resets boards that use the ESP32's integrated USB peripheral (for
+// example the ESP32-S2) and takes them out of download mode. We therefore use
+// access(2), which checks the calling process' permissions non-destructively.
+func checkPortWritable(port string) error {
+	const wOK = 0x2 // W_OK
+	return syscall.Access(port, wOK)
+}

--- a/cmd/jag/commands/port_writable_windows.go
+++ b/cmd/jag/commands/port_writable_windows.go
@@ -1,0 +1,14 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+//go:build windows
+
+package commands
+
+// checkPortWritable is a no-op on Windows. The caller already skips the port
+// writability check there (the dialout/uucp group issue does not exist on
+// Windows), so this exists only to satisfy the build on all platforms.
+func checkPortWritable(port string) error {
+	return nil
+}


### PR DESCRIPTION
## Problem

Flashing an ESP32-S2 over its integrated USB peripheral broke after the chip-type probe was added in #641. The probe runs a separate `esptool chip_id` before flashing, and any serial interaction resets the S2 out of its manually-entered download mode — its USB port disappears, and the subsequent flash fails with `no such file or directory`.

## Why not just fix the probe

There is no reliable way to probe these boards without disturbing them (confirmed on hardware):

| Probe mode | Result |
|---|---|
| resets afterwards (`--after hard-reset`, ± stub) | board **always** disappears → flash fails |
| `--after no-reset` | board stays, but the flash's own connect is **~50% flaky** (reproduced PASS, PASS, FAIL on identical commands, tracking whether the USB port re-enumerates) |
| **no probe** (`--chip=…`) | **100% reliable** — single `write-flash` session |

The flash itself was never the problem; the extra probe session was.

## Fix

- **flash.go** — after probing, if the port has vanished, abort cleanly with an actionable message naming the exact recovery command (`--chip=<chip>`), instead of printing a note and then failing the flash with a confusing second error. `--chip=…` already bypasses the probe.
- **firmware_flash.go** — drop the redundant `"failed to probe chip type:"` re-wrap (`ProbeChipType` already prefixes its own errors, so genuine failures double-prefixed).
- **port_writable_{unix,windows}.go** — the pre-flash port-writability check now uses `access(2)` instead of opening the port for writing and closing it. The old open/close toggled DTR/RTS and reset the S2 right before flashing — which would have broken the `--chip` path too.

No cgo, no platform-specific USB code; builds cgo-free on Linux, macOS (amd64 + arm64), and Windows.

## Testing

Verified end-to-end on an ESP32-S2 (integrated USB, `/dev/ttyACM2`):

- `jag flash` → clean abort: *"the board left download mode after probing its chip type … run again with `--chip=esp32s2` to skip the chip-type probe."*
- `jag flash --chip=esp32s2` → no `chip_id` probe, single `write-flash`, wrote 1.33 MB, exit 0.