### PR TITLE
Prepare release.

### DIFF
--- a/cmd/jag/main.go
+++ b/cmd/jag/main.go
@@ -14,8 +14,8 @@ import (
 
 var (
 	// When updating the version here, also update it in debian/changelog.
-	version    = "v1.68.0"
-	sdkVersion = "v2.0.0-alpha.195"
+	version    = "v1.69.0"
+	sdkVersion = "v2.0.0-alpha.196"
 )
 
 var buildDate = "unknown"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+jaguar (1.69.0-1) unstable; urgency=medium
+
+  * Update SDK to v2.0.0-alpha.196.
+  * Fix ESP32-S2 flashing broken by the chip-type probe.
+
+ -- Toit contributors <contact@toit.io>  Sun, 26 Jul 2026 22:14:12 +0200
+
 jaguar (1.68.0-1) unstable; urgency=medium
 
   * Update SDK to v2.0.0-alpha.195.


### PR DESCRIPTION
## Summary

- prepare Jaguar v1.69.0
- update the bundled Toit SDK to v2.0.0-alpha.196
- update the Debian changelog for the SDK bump and ESP32-S2 flashing fix

## Testing

- go test ./...
- compile Toit assets with SDK v2.0.0-alpha.196
- make test (firmware extraction for ESP32, ESP32-C3, ESP32-C6, ESP32-S2, and ESP32-S3)