### PR TITLE
Migrate GPIO construction for SDK 2.0.0-alpha.196

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 environment:
-  sdk: ^2.0.0-alpha.194.1
+  sdk: ^2.0.0-alpha.196
 dependencies:
   http:
     url: github.com/toitlang/pkg-http

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 environment:
-  sdk: ^2.0.0-alpha.144
+  sdk: ^2.0.0-alpha.194.1
 dependencies:
   http:
     url: github.com/toitlang/pkg-http

--- a/src/uart.toit
+++ b/src/uart.toit
@@ -5,7 +5,6 @@
 import encoding.base64
 import encoding.json
 import encoding.ubjson
-import gpio
 import io
 import io show LITTLE-ENDIAN
 import log
@@ -24,9 +23,8 @@ class EndpointUart implements Endpoint:
 
   run device/Device -> none:
     logger.debug "starting endpoint"
-    rx := gpio.Pin config_["rx"]
     port := uart.Port
-        --rx=rx
+        --rx=config_["rx"]
         --tx=null
         --baud-rate=config_.get "baud" --if-absent=: 115200
 
@@ -39,7 +37,6 @@ class EndpointUart implements Endpoint:
       client.run
     finally:
       port.close
-      rx.close
 
   name -> string:
     return "uart"


### PR DESCRIPTION
## Summary

- update GPIO/peripheral construction for the SDK integer-pin API
- require Toit SDK `^2.0.0-alpha.196`
- modernize the package publish workflow where needed

Part of the SDK 196 package migration.