### PR TITLE
Prepare release.

### DIFF
--- a/cmd/jag/main.go
+++ b/cmd/jag/main.go
@@ -14,8 +14,8 @@ import (
 
 var (
 	// When updating the version here, also update it in debian/changelog.
-	version    = "v1.69.0"
-	sdkVersion = "v2.0.0-alpha.196"
+	version    = "v1.70.0"
+	sdkVersion = "v2.0.0-alpha.197"
 )
 
 var buildDate = "unknown"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+jaguar (1.70.0-1) unstable; urgency=medium
+
+  * Update SDK to v2.0.0-alpha.197.
+  * Support jag watch on host.
+  * Migrate GPIO construction to the SDK integer-pin API.
+
+ -- Toit contributors <contact@toit.io>  Thu, 06 Aug 2026 01:28:39 +0200
+
 jaguar (1.69.0-1) unstable; urgency=medium
 
   * Update SDK to v2.0.0-alpha.196.


### PR DESCRIPTION
## Summary

- prepare Jaguar v1.70.0
- update the bundled Toit SDK to v2.0.0-alpha.197
- update the Debian changelog for host-side `jag watch` support and the GPIO API migration

## Testing

- `go test ./...`
- compile Jaguar assets with Toit SDK v2.0.0-alpha.197
- `jag setup --check`
- `make test`
