### PR TITLE
Bundle esptool for source SDKs and test flashing in QEMU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,23 @@ jobs:
       - name: Run tests
         run: |
           make test
+
+      - name: Install latest Toit QEMU release
+        if: runner.os == 'Linux'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          QEMU_VERSION="$(gh release view --repo toitlang/qemu --json tagName --jq .tagName)"
+          QEMU_ARCHIVE="qemu-toit-${QEMU_VERSION}-linux-x86_64.tar.gz"
+          QEMU_DIR="${RUNNER_TEMP}/toit-qemu"
+          mkdir -p "${QEMU_DIR}"
+          gh release download "${QEMU_VERSION}" --repo toitlang/qemu \
+            --pattern "${QEMU_ARCHIVE}" --pattern SHA256SUMS --dir "${QEMU_DIR}"
+          cd "${QEMU_DIR}"
+          grep " ${QEMU_ARCHIVE}$" SHA256SUMS | sha256sum --check
+          tar -xf "${QEMU_ARCHIVE}"
+          echo "QEMU_SYSTEM_XTENSA=${QEMU_DIR}/qemu-toit-${QEMU_VERSION}-linux-x86_64/bin/qemu-system-xtensa" >> "${GITHUB_ENV}"
+
+      - name: Test flashing an ESP32 in QEMU
+        if: runner.os == 'Linux'
+        run: tests/qemu-flash-test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,21 +43,11 @@ jobs:
         run: |
           make test
 
-      - name: Install latest Toit QEMU release
+      - name: Install Toit QEMU
         if: runner.os == 'Linux'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          QEMU_VERSION="$(gh release view --repo toitlang/qemu --json tagName --jq .tagName)"
-          QEMU_ARCHIVE="qemu-toit-${QEMU_VERSION}-linux-x86_64.tar.gz"
-          QEMU_DIR="${RUNNER_TEMP}/toit-qemu"
-          mkdir -p "${QEMU_DIR}"
-          gh release download "${QEMU_VERSION}" --repo toitlang/qemu \
-            --pattern "${QEMU_ARCHIVE}" --pattern SHA256SUMS --dir "${QEMU_DIR}"
-          cd "${QEMU_DIR}"
-          grep " ${QEMU_ARCHIVE}$" SHA256SUMS | sha256sum --check
-          tar -xf "${QEMU_ARCHIVE}"
-          echo "QEMU_SYSTEM_XTENSA=${QEMU_DIR}/qemu-toit-${QEMU_VERSION}-linux-x86_64/bin/qemu-system-xtensa" >> "${GITHUB_ENV}"
+        uses: toitlang/action-setup@v1
+        with:
+          qemu-version: latest
 
       - name: Test flashing an ESP32 in QEMU
         if: runner.os == 'Linux'

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ $(JAG_TOIT_DEPENDENCIES): $(SDK_BUILD_MARKER)
 # use the rule once per invocation of this Makefile.
 $(SDK_BUILD_MARKER):
 	make -C $(JAG_TOIT_REPO_PATH) version-file esp32
+	make -C $(JAG_TOIT_REPO_PATH) install-esptool
 	mkdir -p $(BUILD_DIR)
 	echo "$(BUILD_DATE)" > $@
 

--- a/cmd/jag/commands/util.go
+++ b/cmd/jag/commands/util.go
@@ -170,24 +170,7 @@ func (s *SDK) AssetsTool(ctx context.Context, args ...string) *exec.Cmd {
 }
 
 func (s *SDK) FirmwareTool(ctx context.Context, args ...string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, s.ToitPath(), append([]string{"tool", "firmware"}, args...)...)
-	cmd.Env = environmentWithoutToitRepoPath()
-	return cmd
-}
-
-// JAG_TOIT_REPO_PATH tells Jaguar where a source-built SDK and its envelopes
-// live. Firmware tools are already launched by absolute path from that SDK and
-// must not interpret this Jaguar-specific setting as an esptool override.
-func environmentWithoutToitRepoPath() []string {
-	prefix := directory.ToitRepoPathEnv + "="
-	environment := os.Environ()
-	result := make([]string, 0, len(environment))
-	for _, entry := range environment {
-		if !strings.HasPrefix(entry, prefix) {
-			result = append(result, entry)
-		}
-	}
-	return result
+	return exec.CommandContext(ctx, s.ToitPath(), append([]string{"tool", "firmware"}, args...)...)
 }
 
 type EspToolOutput struct {
@@ -197,9 +180,7 @@ type EspToolOutput struct {
 
 func (s *SDK) EspToolCommand(ctx context.Context) ([]string, error) {
 	args := []string{"--output-format", "json", "tool", "firmware", "tool", "esptool", "-e", "unused"}
-	cmd := exec.CommandContext(ctx, s.ToitPath(), args...)
-	cmd.Env = environmentWithoutToitRepoPath()
-	out, err := cmd.Output()
+	out, err := exec.CommandContext(ctx, s.ToitPath(), args...).Output()
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/jag/commands/util.go
+++ b/cmd/jag/commands/util.go
@@ -170,7 +170,24 @@ func (s *SDK) AssetsTool(ctx context.Context, args ...string) *exec.Cmd {
 }
 
 func (s *SDK) FirmwareTool(ctx context.Context, args ...string) *exec.Cmd {
-	return exec.CommandContext(ctx, s.ToitPath(), append([]string{"tool", "firmware"}, args...)...)
+	cmd := exec.CommandContext(ctx, s.ToitPath(), append([]string{"tool", "firmware"}, args...)...)
+	cmd.Env = environmentWithoutToitRepoPath()
+	return cmd
+}
+
+// JAG_TOIT_REPO_PATH tells Jaguar where a source-built SDK and its envelopes
+// live. Firmware tools are already launched by absolute path from that SDK and
+// must not interpret this Jaguar-specific setting as an esptool override.
+func environmentWithoutToitRepoPath() []string {
+	prefix := directory.ToitRepoPathEnv + "="
+	environment := os.Environ()
+	result := make([]string, 0, len(environment))
+	for _, entry := range environment {
+		if !strings.HasPrefix(entry, prefix) {
+			result = append(result, entry)
+		}
+	}
+	return result
 }
 
 type EspToolOutput struct {
@@ -180,7 +197,9 @@ type EspToolOutput struct {
 
 func (s *SDK) EspToolCommand(ctx context.Context) ([]string, error) {
 	args := []string{"--output-format", "json", "tool", "firmware", "tool", "esptool", "-e", "unused"}
-	out, err := exec.CommandContext(ctx, s.ToitPath(), args...).Output()
+	cmd := exec.CommandContext(ctx, s.ToitPath(), args...)
+	cmd.Env = environmentWithoutToitRepoPath()
+	out, err := cmd.Output()
 	if err != nil {
 		return nil, err
 	}

--- a/tests/qemu-flash-test.sh
+++ b/tests/qemu-flash-test.sh
@@ -53,16 +53,6 @@ fi
   --exclude-jaguar \
   --output="${TEMP_DIR}/base.bin"
 
-# Recreate the source-tree layout selected by JAG_TOIT_REPO_PATH using the
-# actual downloaded SDK and envelope. This is the configuration from the bug
-# report: it must still select the SDK's bundle, not a Python esptool module.
-TOIT_REPO_PATH="${TEMP_DIR}/toit"
-mkdir -p "${TOIT_REPO_PATH}/build/host" "${TOIT_REPO_PATH}/build/esp32"
-ln -s "${SDK_PATH}" "${TOIT_REPO_PATH}/build/host/sdk"
-ln -s "$(dirname "${SDK_PATH}")/envelopes/firmware-esp32.envelope" \
-  "${TOIT_REPO_PATH}/build/esp32/firmware.envelope"
-export JAG_TOIT_REPO_PATH="${TOIT_REPO_PATH}"
-
 # A 4 MiB flash drive matches the default ESP32 firmware envelope. Strap mode
 # 0x0f starts the ESP32 ROM UART downloader instead of booting from flash.
 truncate --size=4M "${TEMP_DIR}/flash.bin"

--- a/tests/qemu-flash-test.sh
+++ b/tests/qemu-flash-test.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2026 Toitware ApS. All rights reserved.
+# Use of this source code is governed by an MIT-style license that can be
+# found in the LICENSE file.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+JAG="${JAG:-${ROOT_DIR}/build/jag}"
+QEMU_SYSTEM_XTENSA="${QEMU_SYSTEM_XTENSA:-qemu-system-xtensa}"
+QEMU_TIMEOUT_TICKS="${QEMU_TIMEOUT_TICKS:-300}"
+
+if [[ ! -x "${JAG}" ]]; then
+  echo "Jaguar executable is not executable: ${JAG}" >&2
+  exit 2
+fi
+if ! command -v "${QEMU_SYSTEM_XTENSA}" >/dev/null 2>&1; then
+  echo "QEMU executable not found: ${QEMU_SYSTEM_XTENSA}" >&2
+  exit 2
+fi
+
+TEMP_DIR="$(mktemp -d)"
+QEMU_PID=""
+QEMU_LOG="${TEMP_DIR}/qemu.log"
+
+cleanup() {
+  if [[ -n "${QEMU_PID}" ]]; then
+    kill "${QEMU_PID}" 2>/dev/null || true
+    wait "${QEMU_PID}" 2>/dev/null || true
+  fi
+  rm -rf "${TEMP_DIR}"
+}
+trap cleanup EXIT
+
+# Download/cache the real published envelope, and verify the SDK provided by
+# `jag setup` has the bundled esptool this test is intended to exercise.
+SDK_PATH="$("${JAG}" setup --print-path sdk)"
+BUNDLED_ESPTOOL="${SDK_PATH}/lib/toit/bin/esptool"
+if [[ ! -x "${BUNDLED_ESPTOOL}" ]]; then
+  echo "Bundled esptool is not executable: ${BUNDLED_ESPTOOL}" >&2
+  exit 2
+fi
+if [[ "$("${BUNDLED_ESPTOOL}" version)" != *"esptool v5."* ]]; then
+  echo "The bundled esptool is not version 5." >&2
+  exit 2
+fi
+"${JAG}" \
+  --no-analytics \
+  --wifi-ssid=test --wifi-password=test \
+  firmware extract esp32 \
+  --chip=esp32 \
+  --exclude-jaguar \
+  --output="${TEMP_DIR}/base.bin"
+
+# Recreate the source-tree layout selected by JAG_TOIT_REPO_PATH using the
+# actual downloaded SDK and envelope. This is the configuration from the bug
+# report: it must still select the SDK's bundle, not a Python esptool module.
+TOIT_REPO_PATH="${TEMP_DIR}/toit"
+mkdir -p "${TOIT_REPO_PATH}/build/host" "${TOIT_REPO_PATH}/build/esp32"
+ln -s "${SDK_PATH}" "${TOIT_REPO_PATH}/build/host/sdk"
+ln -s "$(dirname "${SDK_PATH}")/envelopes/firmware-esp32.envelope" \
+  "${TOIT_REPO_PATH}/build/esp32/firmware.envelope"
+export JAG_TOIT_REPO_PATH="${TOIT_REPO_PATH}"
+
+# A 4 MiB flash drive matches the default ESP32 firmware envelope. Strap mode
+# 0x0f starts the ESP32 ROM UART downloader instead of booting from flash.
+truncate --size=4M "${TEMP_DIR}/flash.bin"
+"${QEMU_SYSTEM_XTENSA}" \
+  -M esp32 \
+  -accel tcg,thread=single \
+  -global driver=esp32.gpio,property=strap_mode,value=15 \
+  -display none \
+  -monitor none \
+  -no-reboot \
+  -serial pty \
+  -drive "file=${TEMP_DIR}/flash.bin,if=mtd,format=raw" \
+  >"${QEMU_LOG}" 2>&1 &
+QEMU_PID="$!"
+
+SERIAL_PORT=""
+for ((tick = 0; tick < QEMU_TIMEOUT_TICKS; tick++)); do
+  SERIAL_PORT="$(awk '/char device redirected to/ { print $5; exit }' "${QEMU_LOG}")"
+  if [[ -n "${SERIAL_PORT}" ]]; then
+    break
+  fi
+  if ! kill -0 "${QEMU_PID}" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if [[ -z "${SERIAL_PORT}" ]]; then
+  echo "Timed out waiting for QEMU's serial port." >&2
+  cat "${QEMU_LOG}" >&2
+  exit 1
+fi
+
+"${JAG}" \
+  --no-analytics \
+  --wifi-ssid=test --wifi-password=test \
+  flash \
+  --chip=esp32 \
+  --port="${SERIAL_PORT}" \
+  --skip-port-check \
+  --exclude-jaguar
+
+echo "PASS: Jaguar flashed an ESP32 in QEMU with its SDK's bundled esptool"


### PR DESCRIPTION
## Summary

- install the pinned bundled esptool when Jaguar builds a source SDK
- use `toitlang/action-setup` to install and verify QEMU in CI
- verify the pinned Jaguar SDK contains esptool 5 and perform a real `jag flash` against an ESP32 QEMU

The companion Toit change removes the `JAG_TOIT_REPO_PATH` esptool override and makes normal discovery prefer the SDK bundle: https://github.com/toitlang/toit/pull/3164

## Testing

- reproduced the Python esptool 4.8.1 fallback with `JAG_TOIT_REPO_PATH`
- flashed and hash-verified all firmware regions on an ESP32 QEMU using the released SDK bundle
- `go test ./cmd/jag/commands/...`
- shell syntax and diff checks