### PR TITLE
Add firmware flag to disable UDP advertisements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,7 @@ jobs:
       - name: Test flashing an ESP32 in QEMU
         if: runner.os == 'Linux'
         run: tests/qemu-flash-test.sh
+
+      - name: Test UDP advertisement configuration in QEMU
+        if: runner.os == 'Linux'
+        run: tests/qemu-udp-test.sh

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ download-sdk: $(BUILD_DIR)/$(JAG_BINARY)
 
 .PHONY: test
 test: $(BUILD_DIR)/$(JAG_BINARY)
+	go test ./...
 	@# For now just try to extract images for all chips.
 	@for chip in esp32 esp32c3 esp32c6 esp32s2 esp32s3; do \
 		set -e; \

--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ credentials, but be aware that the tooling requires
 jag flash
 ```
 
+To keep Jaguar's HTTP endpoint enabled without broadcasting UDP device-discovery
+advertisements, pass `--disable-udp`. The option is also available when updating
+firmware over WiFi:
+
+``` sh
+jag flash --disable-udp
+jag firmware update --disable-udp
+```
+
 If you want to avoid typing the WiFi credentials every time you flash, you can store
 them in Jaguar's config file with:
 

--- a/cmd/jag/commands/firmware_flash.go
+++ b/cmd/jag/commands/firmware_flash.go
@@ -27,6 +27,7 @@ func addFirmwareFlashFlags(cmd *cobra.Command, nameHelp string) {
 	cmd.Flags().StringP("chip", "c", "auto", "chip of the target device")
 	cmd.Flags().String("wifi-ssid", "", "default WiFi network name")
 	cmd.Flags().String("wifi-password", "", "default WiFi password")
+	cmd.Flags().Bool("disable-udp", false, "disable UDP device discovery advertisements")
 	cmd.Flags().Bool("exclude-jaguar", false, "don't install the Jaguar service")
 	cmd.Flags().Int("uart-endpoint-rx", -1, "add a UART endpoint to the device listening on the given pin")
 	cmd.Flags().MarkHidden("uart-endpoint-rx")
@@ -79,6 +80,10 @@ func withFirmware(cmd *cobra.Command, args []string, probeChip probeChip, device
 	}
 
 	wifiSSID, wifiPassword, err := getWifiCredentials(cmd)
+	if err != nil {
+		return err
+	}
+	disableUDP, err := cmd.Flags().GetBool("disable-udp")
 	if err != nil {
 		return err
 	}
@@ -153,6 +158,7 @@ func withFirmware(cmd *cobra.Command, args []string, probeChip probeChip, device
 		Chip:         chip,
 		WifiSsid:     wifiSSID,
 		WifiPassword: wifiPassword,
+		DisableUDP:   disableUDP,
 	}
 
 	excludeJaguar, err := cmd.Flags().GetBool("exclude-jaguar")
@@ -229,11 +235,7 @@ func BuildFirmwareEnvelope(ctx context.Context, envelope EnvelopeOptions, device
 			return nil, err
 		}
 
-		configAssetMap := map[string]interface{}{
-			"id":   device.Id,
-			"name": device.Name,
-			"chip": device.Chip,
-		}
+		configAssetMap := device.getJaguarConfig()
 		if uartEndpointOptions != nil {
 			configAssetMap["endpointUart"] = uartEndpointOptions
 		}
@@ -315,11 +317,24 @@ type DeviceOptions struct {
 	Chip         string
 	WifiSsid     string
 	WifiPassword string
+	DisableUDP   bool
 }
 
 type EnvelopeOptions struct {
 	Path          string
 	ExcludeJaguar bool
+}
+
+func (d DeviceOptions) getJaguarConfig() map[string]interface{} {
+	config := map[string]interface{}{
+		"id":   d.Id,
+		"name": d.Name,
+		"chip": d.Chip,
+	}
+	if d.DisableUDP {
+		config["jag.disable-udp"] = true
+	}
+	return config
 }
 
 func (d DeviceOptions) GetConfig() map[string]interface{} {

--- a/cmd/jag/commands/firmware_flash_test.go
+++ b/cmd/jag/commands/firmware_flash_test.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestFirmwareCommandsHaveDisableUDPFlag(t *testing.T) {
+	tests := []struct {
+		name    string
+		command *cobra.Command
+	}{
+		{"flash", FlashCmd()},
+		{"firmware update", FirmwareUpdateCmd()},
+		{"firmware extract", FirmwareExtractCmd()},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			flag := test.command.Flags().Lookup("disable-udp")
+			if flag == nil {
+				t.Fatal("missing --disable-udp flag")
+			}
+			if flag.DefValue != "false" {
+				t.Fatalf("--disable-udp default is %q, want false", flag.DefValue)
+			}
+		})
+	}
+}
+
+func TestDeviceOptionsJaguarConfigDisableUDP(t *testing.T) {
+	withoutFlag := (DeviceOptions{}).getJaguarConfig()
+	if _, ok := withoutFlag["jag.disable-udp"]; ok {
+		t.Fatal("jag.disable-udp is present without --disable-udp")
+	}
+
+	withFlag := (DeviceOptions{DisableUDP: true}).getJaguarConfig()
+	if value, ok := withFlag["jag.disable-udp"]; !ok || value != true {
+		t.Fatalf("jag.disable-udp is %#v, want true", value)
+	}
+}

--- a/tests/qemu-udp-test.sh
+++ b/tests/qemu-udp-test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2026 Toit contributors.
+# Use of this source code is governed by an MIT-style license that can be
+# found in the LICENSE file.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+JAG="${JAG:-${ROOT_DIR}/build/jag}"
+QEMU_SYSTEM_XTENSA="${QEMU_SYSTEM_XTENSA:-qemu-system-xtensa}"
+QEMU_TIMEOUT_TICKS="${QEMU_TIMEOUT_TICKS:-300}"
+
+if [[ ! -x "${JAG}" ]]; then
+  echo "Jaguar executable is not executable: ${JAG}" >&2
+  exit 2
+fi
+if ! command -v "${QEMU_SYSTEM_XTENSA}" >/dev/null 2>&1; then
+  echo "QEMU executable not found: ${QEMU_SYSTEM_XTENSA}" >&2
+  exit 2
+fi
+
+TEMP_DIR="$(mktemp -d)"
+QEMU_PID=""
+
+stop_qemu() {
+  if [[ -n "${QEMU_PID}" ]]; then
+    kill "${QEMU_PID}" 2>/dev/null || true
+    wait "${QEMU_PID}" 2>/dev/null || true
+    QEMU_PID=""
+  fi
+}
+
+cleanup() {
+  stop_qemu
+  rm -rf "${TEMP_DIR}"
+}
+trap cleanup EXIT
+
+build_image() {
+  local output="$1"
+  shift
+  "${JAG}" \
+    --no-analytics \
+    firmware extract esp32-qemu \
+    --wifi-ssid=test --wifi-password=test \
+    --name=qemu-udp-test \
+    --output="${output}" \
+    "$@"
+}
+
+run_image() {
+  local image="$1"
+  local log="$2"
+  local capture="$3"
+
+  "${QEMU_SYSTEM_XTENSA}" \
+    -M esp32 \
+    -accel tcg,thread=single \
+    -display none \
+    -monitor none \
+    -no-reboot \
+    -serial "file:${log}" \
+    -drive "file=${image},if=mtd,format=raw" \
+    -netdev user,id=network \
+    -device open_eth,netdev=network \
+    -object "filter-dump,id=capture,netdev=network,file=${capture}" \
+    >/dev/null 2>&1 &
+  QEMU_PID="$!"
+
+  for ((tick = 0; tick < QEMU_TIMEOUT_TICKS; tick++)); do
+    if grep -a -Fq "running Jaguar device" "${log}" 2>/dev/null; then
+      # Identity packets are sent every 200ms. Allow several opportunities
+      # for an advertisement to reach the packet capture.
+      sleep 2
+      stop_qemu
+      return
+    fi
+    if ! kill -0 "${QEMU_PID}" 2>/dev/null; then
+      break
+    fi
+    sleep 0.1
+  done
+
+  stop_qemu
+  echo "Timed out waiting for Jaguar to start in QEMU." >&2
+  cat "${log}" >&2
+  exit 1
+}
+
+build_image "${TEMP_DIR}/udp-enabled.bin"
+build_image "${TEMP_DIR}/udp-disabled.bin" --disable-udp
+
+run_image \
+  "${TEMP_DIR}/udp-enabled.bin" \
+  "${TEMP_DIR}/udp-enabled.log" \
+  "${TEMP_DIR}/udp-enabled.pcap"
+run_image \
+  "${TEMP_DIR}/udp-disabled.bin" \
+  "${TEMP_DIR}/udp-disabled.log" \
+  "${TEMP_DIR}/udp-disabled.pcap"
+
+if ! grep -a -Fq "jaguar.identify" "${TEMP_DIR}/udp-enabled.pcap"; then
+  echo "Jaguar did not advertise its identity without --disable-udp." >&2
+  exit 1
+fi
+if grep -a -Fq "jaguar.identify" "${TEMP_DIR}/udp-disabled.pcap"; then
+  echo "Jaguar advertised its identity with --disable-udp." >&2
+  exit 1
+fi
+
+echo "PASS: --disable-udp suppresses Jaguar UDP advertisements in QEMU"

--- a/tests/qemu-udp-test.sh
+++ b/tests/qemu-udp-test.sh
@@ -42,8 +42,8 @@ build_image() {
   shift
   "${JAG}" \
     --no-analytics \
-    firmware extract esp32-qemu \
-    --wifi-ssid=test --wifi-password=test \
+    firmware extract esp32 \
+    --wifi-ssid="Open Wifi" --wifi-password= \
     --name=qemu-udp-test \
     --output="${output}" \
     "$@"
@@ -53,6 +53,7 @@ run_image() {
   local image="$1"
   local log="$2"
   local capture="$3"
+  local qemu_log="${log}.qemu"
 
   "${QEMU_SYSTEM_XTENSA}" \
     -M esp32 \
@@ -62,10 +63,9 @@ run_image() {
     -no-reboot \
     -serial "file:${log}" \
     -drive "file=${image},if=mtd,format=raw" \
-    -netdev user,id=network \
-    -device open_eth,netdev=network \
+    -nic user,id=network,model=esp32_wifi \
     -object "filter-dump,id=capture,netdev=network,file=${capture}" \
-    >/dev/null 2>&1 &
+    >"${qemu_log}" 2>&1 &
   QEMU_PID="$!"
 
   for ((tick = 0; tick < QEMU_TIMEOUT_TICKS; tick++)); do
@@ -83,7 +83,8 @@ run_image() {
   done
 
   stop_qemu
-  echo "Timed out waiting for Jaguar to start in QEMU." >&2
+  echo "Failed waiting for Jaguar to start in QEMU." >&2
+  cat "${qemu_log}" >&2
   cat "${log}" >&2
   exit 1
 }


### PR DESCRIPTION
## Summary
- add --disable-udp to flash, firmware update, and firmware extract
- persist jag.disable-udp in the Jaguar service configuration
- document the new flag
- add unit coverage and a QEMU packet-capture integration test for both flag states

## Testing
- GOCACHE=/tmp/jaguar-go-cache go test -count=1 ./...
- GOCACHE=/tmp/jaguar-go-cache go vet ./...
- bash -n tests/qemu-udp-test.sh
- built firmware images locally with and without --disable-udp
- ran tests/qemu-udp-test.sh locally with qemu-toit-v9.2.2-toitlang.2-linux-x86_64

The QEMU test verifies that the default firmware emits jaguar.identify advertisements and that --disable-udp suppresses them while the Jaguar HTTP endpoint still starts.