### PR TITLE
Fail for unavailable explicit serial ports

### DIFF
--- a/cmd/jag/commands/flash.go
+++ b/cmd/jag/commands/flash.go
@@ -35,7 +35,7 @@ func FlashCmd() *cobra.Command {
 				return err
 			}
 			if !shouldSkipPortCheck {
-				if port, err = CheckPort(port); err != nil {
+				if port, err = checkPort(port, cmd.Flags().Changed("port")); err != nil {
 					return err
 				}
 			}

--- a/cmd/jag/commands/monitor.go
+++ b/cmd/jag/commands/monitor.go
@@ -33,7 +33,7 @@ func MonitorCmd() *cobra.Command {
 				return err
 			}
 
-			if port, err = CheckPort(port); err != nil {
+			if port, err = checkPort(port, cmd.Flags().Changed("port")); err != nil {
 				return err
 			}
 

--- a/cmd/jag/commands/port.go
+++ b/cmd/jag/commands/port.go
@@ -132,12 +132,19 @@ func ConfiguredPort() string {
 }
 
 func CheckPort(port string) (string, error) {
+	return checkPort(port, false)
+}
+
+func checkPort(port string, explicitlySet bool) (string, error) {
 	exists, err := PortExists(port)
 	if err != nil {
 		return "", err
 	}
 	if exists {
 		return port, nil
+	}
+	if explicitlySet {
+		return "", fmt.Errorf("the port '%s' was not found", port)
 	}
 
 	cfg, err := directory.GetDeviceConfig()

--- a/cmd/jag/commands/port_test.go
+++ b/cmd/jag/commands/port_test.go
@@ -1,0 +1,40 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestExplicitUnavailablePortFails(t *testing.T) {
+	const unavailablePort = "/jaguar-test-port-that-does-not-exist"
+
+	commands := []struct {
+		name string
+		cmd  func() *cobra.Command
+	}{
+		{"flash", FlashCmd},
+		{"monitor", MonitorCmd},
+	}
+
+	for _, test := range commands {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := test.cmd()
+			cmd.SetArgs([]string{"--port", unavailablePort})
+			cmd.SilenceErrors = true
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("command succeeded with an unavailable explicit port")
+			}
+			if !strings.Contains(err.Error(), unavailablePort) {
+				t.Fatalf("error %q does not identify the unavailable port", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When an explicit --port value is unavailable, fail with an error identifying that port instead of falling back to the interactive port picker.

Omitted port flags retain the existing configured-port and interactive-selection behavior. This applies to both flash and monitor, while --skip-port-check remains an intentional bypass for flash.

Tests:
- go test ./...