### PR TITLE
Prepare Jaguar v1.71.0

### DIFF
--- a/cmd/jag/main.go
+++ b/cmd/jag/main.go
@@ -14,8 +14,8 @@ import (
 
 var (
 	// When updating the version here, also update it in debian/changelog.
-	version    = "v1.70.0"
-	sdkVersion = "v2.0.0-alpha.197"
+	version    = "v1.71.0"
+	sdkVersion = "v2.0.0-alpha.198"
 )
 
 var buildDate = "unknown"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+jaguar (1.71.0-1) unstable; urgency=medium
+
+  * New upstream release.
+
+ -- Toit contributors <contact@toit.io>  Wed, 19 Aug 2026 01:20:07 +0200
+
 jaguar (1.70.0-1) unstable; urgency=medium
 
   * Update SDK to v2.0.0-alpha.197.


### PR DESCRIPTION
## Summary

- prepare Jaguar v1.71.0
- update the bundled Toit SDK to v2.0.0-alpha.198
- add a concise Debian changelog entry for the new upstream release

## Testing

- go test ./...
- release-mode binary reports Jaguar v1.71.0 and SDK v2.0.0-alpha.198
- dpkg-parsechangelog reports 1.71.0-1
- git diff --check